### PR TITLE
first pass at hacking in the context stack

### DIFF
--- a/Scripts/Core/IEditingContext.cs
+++ b/Scripts/Core/IEditingContext.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using UnityEngine;
+
+
+namespace UnityEditor.Experimental.EditorVR
+{
+    /// <summary>
+    /// Implement this interface on a MonoBehavior to create an Editing Context.  Which is a blank space in which to author VR Editing tools.
+    /// 
+    /// Editing Contexts are applied as a stack.  Which means a context can be subverted by a newer context pushed to the top
+    /// of the stack.  When a context pops itself from the stack, the next context on the stack, which had been subverted, is
+    /// revived.
+    /// </summary>
+    public interface IEditingContext
+    {
+        /// <summary>
+        /// Execute cleanup before this context is subverted in favor of a subcontext.  You can assume the context will be revived before it is destroyed.
+        /// </summary>
+        void OnSubvertContext();
+
+        /// <summary>
+        /// Undo whatever was cleaned or is needed to revive.  You can assume this context was previously subverted.
+        /// </summary>
+        void OnReviveContext();
+    }
+
+    public interface IEditingContext<C> : IEditingContext
+    {
+        void Configure(C config);
+    }
+
+}

--- a/Scripts/Core/IEditingContext.cs.meta
+++ b/Scripts/Core/IEditingContext.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 97ed01d6decffae4cb71f9383c3d9b89
+timeCreated: 1487216931
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Utilities/U/U.Object.cs
+++ b/Scripts/Utilities/U/U.Object.cs
@@ -34,7 +34,7 @@ namespace UnityEngine.Experimental.EditorVR.Utilities
 				if (!Application.isPlaying && runInEditMode)
 				{
 					SetRunInEditModeRecursively(go, runInEditMode);
-					go.hideFlags = EditorVR.kDefaultHideFlags;
+					go.hideFlags = VRView.kDefaultHideFlags;
 				}
 #endif
 
@@ -65,7 +65,7 @@ namespace UnityEngine.Experimental.EditorVR.Utilities
 				if (String.IsNullOrEmpty(name))
 					name = "Empty";
 #if UNITY_EDITOR && UNITY_EDITORVR
-				empty = EditorUtility.CreateGameObjectWithHideFlags(name, EditorVR.kDefaultHideFlags);
+				empty = EditorUtility.CreateGameObjectWithHideFlags(name, VRView.kDefaultHideFlags);
 #else
 				empty = new GameObject(name);
 #endif
@@ -83,7 +83,7 @@ namespace UnityEngine.Experimental.EditorVR.Utilities
 			public static Component CreateGameObjectWithComponent(Type type, Transform parent = null)
 			{
 #if UNITY_EDITOR && UNITY_EDITORVR
-				Component component = EditorUtility.CreateGameObjectWithHideFlags(type.Name, EditorVR.kDefaultHideFlags, type).GetComponent(type);
+				Component component = EditorUtility.CreateGameObjectWithHideFlags(type.Name, VRView.kDefaultHideFlags, type).GetComponent(type);
 				if (!Application.isPlaying)
 					SetRunInEditModeRecursively(component.gameObject, true);
 #else


### PR DESCRIPTION
-Moved some code form EditorVR to VRView and added the context stack.  This decouples VRView from EditorVR.

-Added IEditorContext and applied it to EditorVR.

-Added the optional concept of Configuration to Editing Contexts.

This is for discussion purposes.  I have tested it to the extent that I've confirmed that the existing EditorVR still runs with this rewiring.  The integration tests you mentioned on the hangout earlier are a thing I don't have access to.  So I can't confirm if I've created a regression.

This means that Sub-contexts and alternative contexts are not currently tested.  Though you can see how they're supposed to work.

I've left the hotkeys alone and I have not authored a new "root context."  Rather, I've done the minimum wiring to allow such a thing to be built.

Next steps would be to pull an abstract base-class or three from EditorVR from which to inherit and create an alternative Editing Context or two.

Thoughts?

This isn't much code.  I don't want to put too much more effort into it before we've discussed.  We might decide to ditch it and re-write.