### PR TITLE
Fix Vive controller model not showing up

### DIFF
--- a/Scripts/Input/ViveInputToEvents.cs
+++ b/Scripts/Input/ViveInputToEvents.cs
@@ -39,7 +39,7 @@ namespace UnityEngine.Experimental.EditorVR.Input
 
 		public void Update()
 		{
-			var shouldAactivate = false;
+			var isActive = false;
 			TrackedDevicePose_t[] poses = null;
 			var compositor = OpenVR.Compositor;
 			if (compositor != null)
@@ -65,7 +65,7 @@ namespace UnityEngine.Experimental.EditorVR.Input
 					steamDeviceIndex = steamDeviceIndices[(int)hand];
 				}
 
-				shouldAactivate = true;
+				isActive = true;
 
 				int deviceIndex = hand == VRInputDevice.Handedness.Left ? 3 : 4; // TODO change 3 and 4 based on virtual devices defined in InputDeviceManager (using actual hardware available)
 				SendButtonEvents(steamDeviceIndex, deviceIndex);
@@ -73,8 +73,8 @@ namespace UnityEngine.Experimental.EditorVR.Input
 				SendTrackingEvents(steamDeviceIndex, deviceIndex, poses);
 			}
 
-			if (active != shouldAactivate)
-				active = shouldAactivate;
+			if (active != isActive)
+				active = isActive;
 		}
 
 		public const int controllerCount = 10;

--- a/Scripts/Input/ViveInputToEvents.cs
+++ b/Scripts/Input/ViveInputToEvents.cs
@@ -39,7 +39,7 @@ namespace UnityEngine.Experimental.EditorVR.Input
 
 		public void Update()
 		{
-			active = false;
+			var shouldAactivate = false;
 			TrackedDevicePose_t[] poses = null;
 			var compositor = OpenVR.Compositor;
 			if (compositor != null)
@@ -65,13 +65,16 @@ namespace UnityEngine.Experimental.EditorVR.Input
 					steamDeviceIndex = steamDeviceIndices[(int)hand];
 				}
 
-				active = true;
+				shouldAactivate = true;
 
 				int deviceIndex = hand == VRInputDevice.Handedness.Left ? 3 : 4; // TODO change 3 and 4 based on virtual devices defined in InputDeviceManager (using actual hardware available)
 				SendButtonEvents(steamDeviceIndex, deviceIndex);
 				SendAxisEvents(steamDeviceIndex, deviceIndex);
 				SendTrackingEvents(steamDeviceIndex, deviceIndex, poses);
 			}
+
+			if (active != shouldAactivate)
+				active = shouldAactivate;
 		}
 
 		public const int controllerCount = 10;


### PR DESCRIPTION
Turns out deactivating the controller object canceled the SetModelAsync coroutine, causing the model load to fail