### PR TITLE
Hide MiniWorldReference and MiniWorldCamera from hierarchy

### DIFF
--- a/Workspaces/MiniWorld/Scripts/MiniWorld.cs
+++ b/Workspaces/MiniWorld/Scripts/MiniWorld.cs
@@ -84,7 +84,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		private void OnEnable()
 		{
 			if (!referenceTransform)
-				referenceTransform = new GameObject("MiniWorldReference") { hideFlags = HideFlags.DontSave }.transform;
+				referenceTransform = new GameObject("MiniWorldReference") { hideFlags = HideFlags.HideAndDontSave }.transform;
 
 			m_MiniWorldRenderer = ObjectUtils.AddComponent<MiniWorldRenderer>(CameraUtils.GetMainCamera().gameObject);
 			m_MiniWorldRenderer.miniWorld = this;
@@ -96,7 +96,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		private void OnDisable()
 		{
-			if ((referenceTransform.hideFlags & HideFlags.DontSave) != 0)
+			if ((referenceTransform.hideFlags & HideFlags.HideAndDontSave) != 0)
 				ObjectUtils.Destroy(referenceTransform.gameObject);
 
 			if (m_MiniWorldRenderer)

--- a/Workspaces/MiniWorld/Scripts/MiniWorld.cs
+++ b/Workspaces/MiniWorld/Scripts/MiniWorld.cs
@@ -84,7 +84,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		private void OnEnable()
 		{
 			if (!referenceTransform)
-				referenceTransform = new GameObject("MiniWorldReference") { hideFlags = HideFlags.HideAndDontSave }.transform;
+				referenceTransform = ObjectUtils.CreateEmptyGameObject("MiniWorldReference").transform;
 
 			m_MiniWorldRenderer = ObjectUtils.AddComponent<MiniWorldRenderer>(CameraUtils.GetMainCamera().gameObject);
 			m_MiniWorldRenderer.miniWorld = this;
@@ -96,7 +96,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		private void OnDisable()
 		{
-			if ((referenceTransform.hideFlags & HideFlags.HideAndDontSave) != 0)
+			if (referenceTransform)
 				ObjectUtils.Destroy(referenceTransform.gameObject);
 
 			if (m_MiniWorldRenderer)

--- a/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs
+++ b/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs
@@ -51,10 +51,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		void OnEnable()
 		{
-			var go = new GameObject("MiniWorldCamera", typeof(Camera));
+			m_MiniCamera = (Camera)ObjectUtils.CreateGameObjectWithComponent(typeof(Camera));
+			var go = m_MiniCamera.gameObject;
+			go.name = "MiniWorldCamera";
 			go.tag = k_MiniWorldCameraTag;
-			go.hideFlags = HideFlags.HideAndDontSave;
-			m_MiniCamera = go.GetComponent<Camera>();
 			go.SetActive(false);
 			Camera.onPostRender += RenderMiniWorld;
 		}

--- a/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs
+++ b/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs
@@ -53,7 +53,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		{
 			var go = new GameObject("MiniWorldCamera", typeof(Camera));
 			go.tag = k_MiniWorldCameraTag;
-			go.hideFlags = HideFlags.DontSave;
+			go.hideFlags = HideFlags.HideAndDontSave;
 			m_MiniCamera = go.GetComponent<Camera>();
 			go.SetActive(false);
 			Camera.onPostRender += RenderMiniWorld;


### PR DESCRIPTION
It looks like this issue has always been around. I thought about adding an IUsesHideFlags and actually supplying the proper hideflags value, but this would mean switching to a Start() instead of OnEnable since it would need the interface to be hooked up. I was also thinking of using static members and setting them when EVR sets itself up.

This seemed like the cleanest fix.