### PR TITLE
Miniworld Fixes

### DIFF
--- a/Scripts/Core/EditorVR.DirectSelection.cs
+++ b/Scripts/Core/EditorVR.DirectSelection.cs
@@ -135,7 +135,10 @@ namespace UnityEditor.Experimental.EditorVR
 			{
 				// Detach the player head model so that it is not affected by its parent transform
 				if (selection.CompareTag(k_VRPlayerTag))
+				{
+					selection.hideFlags = HideFlags.None;
 					selection.transform.parent = null;
+				}
 			}
 
 			internal void OnObjectsDropped(Transform[] grabbedObjects, Transform rayOrigin)

--- a/Scripts/Core/EditorVR.Viewer.cs
+++ b/Scripts/Core/EditorVR.Viewer.cs
@@ -53,6 +53,7 @@ namespace UnityEditor.Experimental.EditorVR
 
 				evr.StartCoroutine(UpdateCameraRig(endPosition, viewDirection, () =>
 				{
+					playerHead.hideFlags = defaultHideFlags;
 					playerHead.parent = mainCamera;
 					playerHead.localRotation = Quaternion.identity;
 					playerHead.localPosition = Vector3.zero;

--- a/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs
+++ b/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs
@@ -13,6 +13,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		const string k_MiniWorldCameraTag = "MiniWorldCamera";
 		const float k_MinScale = 0.001f;
 
+		[SerializeField]
+		Shader m_ClipShader;
+
 		static int s_DefaultLayer;
 
 		public List<Renderer> ignoreList
@@ -76,7 +79,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				m_MiniCamera.cameraType = CameraType.Game;
 				m_MiniCamera.clearFlags = CameraClearFlags.Nothing;
 				m_MiniCamera.worldToCameraMatrix = GetWorldToCameraMatrix(camera);
-				var shader = Shader.Find("Custom/Custom Clip Planes");
 				var referenceBounds = miniWorld.referenceBounds;
 				var inverseRotation = Quaternion.Inverse(miniWorld.referenceTransform.rotation);
 				Shader.SetGlobalVector("_GlobalClipCenter", inverseRotation * referenceBounds.center);
@@ -101,7 +103,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 					}
 				}
 
-				m_MiniCamera.SetReplacementShader(shader, null);
+				m_MiniCamera.SetReplacementShader(m_ClipShader, null);
 				m_MiniCamera.Render();
 
 				for (var i = 0; i < m_IgnoreList.Count; i++)

--- a/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs.meta
+++ b/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs.meta
@@ -1,10 +1,11 @@
 fileFormatVersion: 2
 guid: 595ec5f9729f0498b803d283e747cb7b
-timeCreated: 1439334988
+timeCreated: 1489602824
 licenseType: Pro
 MonoImporter:
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - m_ClipShader: {fileID: 4800000, guid: fc3ee1f57abcecb47ae3889390740f03, type: 3}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 


### PR DESCRIPTION
I fixed two separate issues. The first becomes immediately clear when you open the miniworld--no clipping. This is because we renamed the shader path for CustomClipPlanes, but didn't update the string literal in MiniWorldRenderer. I replaced the Shader.Find with a serialized reference to the shader. This should be more stable in the future. As a side note, I've been working on a resource checker that can check for this kind of reference, but not the string literal, so this helps us when looking for unused shaders.

This also closes #86 which was caused by the new HideFlags change. Because the player head is hidden, it cannot be added to the selection. In order to direct-manipulate multiple objects, we flow direct grabs through the Selection class, which ignores objects with hide flags. The easiest solution is just to unset hide flags on the player head while you're moving it around.