### PR TITLE
Tiny keyboard fix

### DIFF
--- a/Editor/KeyboardButtonEditor.cs
+++ b/Editor/KeyboardButtonEditor.cs
@@ -15,7 +15,6 @@ namespace UnityEditor.Experimental.EditorVR.UI
 		SerializedProperty m_UseShiftCharacterProperty;
 		SerializedProperty m_ShiftCharacterProperty;
 		SerializedProperty m_ButtonTextProperty;
-		SerializedProperty m_MatchButtonTextToCharacterProperty;
 		SerializedProperty m_ButtonMeshProperty;
 		SerializedProperty m_RepeatOnHoldProperty;
 		SerializedProperty m_WorkspaceButtonProperty;
@@ -30,7 +29,6 @@ namespace UnityEditor.Experimental.EditorVR.UI
 			m_UseShiftCharacterProperty = serializedObject.FindProperty("m_UseShiftCharacter");
 			m_ShiftCharacterProperty = serializedObject.FindProperty("m_ShiftCharacter");
 			m_ButtonTextProperty = serializedObject.FindProperty("m_TextComponent");
-			m_MatchButtonTextToCharacterProperty = serializedObject.FindProperty("m_MatchButtonTextToCharacter");
 			m_ButtonMeshProperty = serializedObject.FindProperty("m_TargetMesh");
 			m_RepeatOnHoldProperty = serializedObject.FindProperty("m_RepeatOnHold");
 			m_WorkspaceButtonProperty = serializedObject.FindProperty("m_WorkspaceButton");
@@ -56,15 +54,8 @@ namespace UnityEditor.Experimental.EditorVR.UI
 			if (m_KeyboardButton.textComponent != null)
 			{
 				EditorGUI.BeginChangeCheck();
-				EditorGUILayout.PropertyField(m_MatchButtonTextToCharacterProperty);
 				if (EditorGUI.EndChangeCheck())
 					UpdateButtonTextAndObjectName(m_CharacterProperty.intValue, updateObjectName);
-
-				if (m_MatchButtonTextToCharacterProperty.boolValue)
-				{
-					if (!m_KeyboardButton.textComponent.font.HasCharacter((char)m_CharacterProperty.intValue))
-						EditorGUILayout.HelpBox("Character not defined in font, consider using an icon", MessageType.Error);
-				}
 			}
 
 			// Handle shift character
@@ -161,9 +152,6 @@ namespace UnityEditor.Experimental.EditorVR.UI
 		void UpdateButtonTextAndObjectName(int input, bool updateName)
 		{
 			var inputString = ((char)input).ToString();
-
-			if (m_MatchButtonTextToCharacterProperty.boolValue)
-				m_KeyboardButton.textComponent.text = inputString;
 
 			// For valid keycodes, use the string version of those for 
 			if (Enum.IsDefined(typeof(KeyCode), input))

--- a/Scripts/Modules/KeyboardModule.cs
+++ b/Scripts/Modules/KeyboardModule.cs
@@ -40,7 +40,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			// Check if the prefab has already been instantiated
 			if (m_NumericKeyboard == null)
 			{
-				m_NumericKeyboard = ObjectUtils.Instantiate(m_NumericKeyboardPrefab.gameObject, CameraUtils.GetCameraRig()).GetComponent<KeyboardUI>();
+				m_NumericKeyboard = ObjectUtils.Instantiate(m_NumericKeyboardPrefab.gameObject, CameraUtils.GetCameraRig(), false).GetComponent<KeyboardUI>();
 				var smoothMotions = m_NumericKeyboard.GetComponentsInChildren<SmoothMotion>(true);
 				foreach (var smoothMotion in smoothMotions)
 				{
@@ -59,7 +59,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			// Check if the prefab has already been instantiated
 			if (m_StandardKeyboard == null)
 			{
-				m_StandardKeyboard = ObjectUtils.Instantiate(m_StandardKeyboardPrefab.gameObject, CameraUtils.GetCameraRig()).GetComponent<KeyboardUI>();
+				m_StandardKeyboard = ObjectUtils.Instantiate(m_StandardKeyboardPrefab.gameObject, CameraUtils.GetCameraRig(), false).GetComponent<KeyboardUI>();
 				var smoothMotions = m_StandardKeyboard.GetComponentsInChildren<SmoothMotion>(true);
 				foreach (var smoothMotion in smoothMotions)
 				{

--- a/Scripts/UI/InputField.cs
+++ b/Scripts/UI/InputField.cs
@@ -14,7 +14,7 @@ using UnityEngine.UI;
 
 namespace UnityEditor.Experimental.EditorVR.UI
 {
-	abstract class InputField : Selectable, ISelectionFlags
+	abstract class InputField : Selectable, ISelectionFlags, IUsesViewerScale
 	{
 		const float k_MoveKeyboardTime = 0.2f;
 		public SelectionFlags selectionFlags
@@ -44,6 +44,8 @@ namespace UnityEditor.Experimental.EditorVR.UI
 		private bool m_KeyboardOpen;
 
 		Coroutine m_MoveKeyboardCoroutine;
+
+		public Func<float> getViewerScale { private get; set; }
 
 		public virtual string text
 		{
@@ -144,7 +146,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
 		IEnumerator MoveKeyboardToInputField(bool instant)
 		{
 			const float kKeyboardYOffset = 0.05f;
-			var targetPosition = transform.position + Vector3.up * kKeyboardYOffset;
+			var targetPosition = transform.position + Vector3.up * kKeyboardYOffset * getViewerScale();
 
 			if (!instant && !m_Keyboard.collapsed)
 			{

--- a/Workspaces/Inspector/Scripts/ListItems/InspectorListItem.cs
+++ b/Workspaces/Inspector/Scripts/ListItems/InspectorListItem.cs
@@ -334,21 +334,25 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			if (!m_DragObject)
 			{
-				foreach (var field in m_InputFields)
-				{
-					field.CloseKeyboard(m_DraggedField == null);
-				}
-
+				InputField inputField = null;
 				var fieldBlock = handle.transform.parent;
 				foreach (Transform child in fieldBlock.transform)
 				{
-					var inputField = child.GetComponent<InputField>();
+					inputField = child.GetComponent<InputField>();
 					if (inputField)
 					{
 						inputField.OpenKeyboard();
 						break;
 					}
 				}
+
+				foreach (var field in m_InputFields)
+				{
+					field.CloseKeyboard(inputField == null);
+				}
+
+				if (inputField)
+					inputField.OpenKeyboard();
 			}
 
 			base.OnDragEnded(handle, eventData);


### PR DESCRIPTION
Fixes #98.

This actually brought up a couple extant issues with the keyboard:

* KeyboardEditor referenced a property which no longer exists
* Swapping between fields caused exceptions due to issues that cropped up when switching from double click to offset-based grabbing

The actual fix for #98 is to set the worldPositionStays argument to false when instantiating the keyboard, and use the viewer scale to set the keyboard offset.