### PR TITLE
Add a "pulse" of full-opacity to the radial menu when unlocking objects

### DIFF
--- a/Menus/RadialMenu/RadialMenu.cs
+++ b/Menus/RadialMenu/RadialMenu.cs
@@ -71,6 +71,8 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
 		public GameObject menuContent { get { return m_RadialMenuUI.gameObject; } }
 
+		public bool opaqueReveal { set { m_RadialMenuUI.opaqueReveal = value; }}
+
 		void Start()
 		{
 			m_RadialMenuUI = instantiateUI(m_RadialMenuPrefab.gameObject).GetComponent<RadialMenuUI>();

--- a/Menus/RadialMenu/Scripts/RadialMenuSlot.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuSlot.cs
@@ -244,7 +244,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 			ObjectUtils.Destroy(m_FrameMaterial);
 		}
 
-		void CorrectIconRotation()
+		public void CorrectIconRotation()
 		{
 			m_IconLookDirection = m_Icon.transform.position + transform.parent.forward * m_IconLookForwardOffset; // set a position offset above the icon, regardless of the icon's rotation
 			m_IconContainer.LookAt(m_IconLookDirection);

--- a/Menus/RadialMenu/Scripts/RadialMenuUI.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuUI.cs
@@ -12,6 +12,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 	sealed class RadialMenuUI : MonoBehaviour, IConnectInterfaces
 	{
 		const int k_SlotCount = 16;
+		const float k_OpaqueRevealDuration = 1f;
 
 		[SerializeField]
 		Sprite m_MissingActionIcon;
@@ -26,6 +27,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 		Coroutine m_VisibilityCoroutine;
 		RadialMenuSlot m_HighlightedButton;
 		float m_PhaseOffset; // Correcting the coordinates, based on actions count, so that the menu is centered at the bottom
+		float m_OpaqueRevealCurrentDuration = 0f;
 
 		public Transform alternateMenuOrigin
 		{
@@ -171,29 +173,24 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 		}
 		private bool m_SemiTransparent;
 
-		public ConnectInterfacesDelegate connectInterfaces { private get; set; }
-
 		public bool opaqueReveal
 		{
 			set
 			{
-				Debug.LogError("REVEAL OPAQUE CALLED!!!!");
-
-				if (m_RevealOpaque != value)
+				if (m_OpaqueReveal != value)
 				{
-					m_RevealOpaque = true;
-					m_OpaqueDuration = 0f;
+					m_OpaqueReveal = true;
+					m_OpaqueRevealCurrentDuration = 0f;
 				}
 			}
 		}
-		bool m_RevealOpaque;
+		bool m_OpaqueReveal;
 
-		const float k_OpaqueDurationMax = 1f;
-		float m_OpaqueDuration = 0f;
+		public ConnectInterfacesDelegate connectInterfaces { private get; set; }
 
 		void OnDisable()
 		{
-			m_RevealOpaque = false;
+			m_OpaqueReveal = false;
 		}
 
 		void Update()
@@ -210,11 +207,11 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 				}
 			}
 
-			if (m_RevealOpaque && (m_OpaqueDuration += Time.unscaledDeltaTime) > k_OpaqueDurationMax)
-				m_RevealOpaque = false;
+			if (m_OpaqueReveal && (m_OpaqueRevealCurrentDuration += Time.unscaledDeltaTime) > k_OpaqueRevealDuration)
+				m_OpaqueReveal = false;
 
 			if (m_Visible) // don't override transparency if the menu is in the process of hiding itself
-				semiTransparent = !m_RadialMenuSlots.Any(x => x.highlighted) && !m_RevealOpaque;
+				semiTransparent = !m_RadialMenuSlots.Any(x => x.highlighted) && !m_OpaqueReveal;
 		}
 
 		public void Setup()

--- a/Menus/RadialMenu/Scripts/RadialMenuUI.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuUI.cs
@@ -179,7 +179,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 			{
 				if (m_OpaqueReveal != value)
 				{
-					m_OpaqueReveal = true;
+					m_OpaqueReveal = value;
 					m_OpaqueRevealCurrentDuration = 0f;
 				}
 			}

--- a/Menus/RadialMenu/Scripts/RadialMenuUI.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuUI.cs
@@ -289,7 +289,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 				for (int i = 0; i < m_RadialMenuSlots.Count; ++i)
 				{
 					if (i < m_Actions.Count)
+					{
 						m_RadialMenuSlots[i].transform.localRotation = Quaternion.Lerp(hiddenSlotRotation, m_RadialMenuSlots[i].visibleLocalRotation, revealAmount * revealAmount);
+						m_RadialMenuSlots[i].CorrectIconRotation();
+					}
 				}
 
 				yield return null;

--- a/Menus/RadialMenu/Scripts/RadialMenuUI.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuUI.cs
@@ -173,6 +173,36 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
 		public ConnectInterfacesDelegate connectInterfaces { private get; set; }
 
+		public bool opaqueReveal
+		{
+			set
+			{
+				Debug.LogError("REVEAL OPAQUE CALLED!!!!");
+
+				if (m_RevealOpaque != value)
+				{
+					m_RevealOpaque = true;
+					m_OpaqueDuration = 0f;
+					//StartCoroutine(maintainOpacity());
+				}
+			}
+		}
+		bool m_RevealOpaque;
+
+		const float k_OpaqueDurationMax = 1f;
+		float m_OpaqueDuration = 0f;
+
+		IEnumerator maintainOpacity()
+		{
+			var duration = 0f;
+			while (duration < 3)
+			{
+				duration += Time.unscaledDeltaTime;
+				yield return null;
+			}
+			m_RevealOpaque = false;
+		}
+
 		void Update()
 		{
 			if (m_Actions != null)
@@ -187,8 +217,16 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 				}
 			}
 
+			if (m_RevealOpaque && m_OpaqueDuration < k_OpaqueDurationMax)
+			{
+				m_OpaqueDuration += Time.unscaledDeltaTime;
+
+				if (m_OpaqueDuration > k_OpaqueDurationMax)
+					m_RevealOpaque = false;
+			}
+
 			if (m_Visible) // don't override transparency if the menu is in the process of hiding itself
-				semiTransparent = !m_RadialMenuSlots.Any(x => x.highlighted);
+				semiTransparent = !m_RadialMenuSlots.Any(x => x.highlighted) && !m_RevealOpaque;
 		}
 
 		public void Setup()

--- a/Menus/RadialMenu/Scripts/RadialMenuUI.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuUI.cs
@@ -183,7 +183,6 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 				{
 					m_RevealOpaque = true;
 					m_OpaqueDuration = 0f;
-					//StartCoroutine(maintainOpacity());
 				}
 			}
 		}
@@ -192,14 +191,8 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 		const float k_OpaqueDurationMax = 1f;
 		float m_OpaqueDuration = 0f;
 
-		IEnumerator maintainOpacity()
+		void OnDisable()
 		{
-			var duration = 0f;
-			while (duration < 3)
-			{
-				duration += Time.unscaledDeltaTime;
-				yield return null;
-			}
 			m_RevealOpaque = false;
 		}
 
@@ -217,13 +210,8 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 				}
 			}
 
-			if (m_RevealOpaque && m_OpaqueDuration < k_OpaqueDurationMax)
-			{
-				m_OpaqueDuration += Time.unscaledDeltaTime;
-
-				if (m_OpaqueDuration > k_OpaqueDurationMax)
-					m_RevealOpaque = false;
-			}
+			if (m_RevealOpaque && (m_OpaqueDuration += Time.unscaledDeltaTime) > k_OpaqueDurationMax)
+				m_RevealOpaque = false;
 
 			if (m_Visible) // don't override transparency if the menu is in the process of hiding itself
 				semiTransparent = !m_RadialMenuSlots.Any(x => x.highlighted) && !m_RevealOpaque;

--- a/Scripts/Core/EditorVR.Menus.cs
+++ b/Scripts/Core/EditorVR.Menus.cs
@@ -254,11 +254,9 @@ namespace UnityEditor.Experimental.EditorVR
 					if (alternateMenu != null)
 					{
 						var flags = deviceData.menuHideFlags[alternateMenu];
-						var visibileDevice = (deviceData.rayOrigin == rayOrigin) && visible;
-						deviceData.menuHideFlags[alternateMenu] = visibileDevice ? flags & ~MenuHideFlags.Hidden : flags | MenuHideFlags.Hidden;
-
-						if (opaqueReveal && visibileDevice)
-							deviceData.menuHideFlags[alternateMenu] = flags | MenuHideFlags.OpaqueReveal;
+						var visibleDevice = (deviceData.rayOrigin == rayOrigin) && visible;
+						flags = opaqueReveal && visibleDevice ? flags | MenuHideFlags.OpaqueReveal : flags;
+						deviceData.menuHideFlags[alternateMenu] = visibleDevice ? flags & ~MenuHideFlags.Hidden : flags | MenuHideFlags.Hidden;
 					}
 				});
 			}

--- a/Scripts/Core/EditorVR.Menus.cs
+++ b/Scripts/Core/EditorVR.Menus.cs
@@ -139,17 +139,10 @@ namespace UnityEditor.Experimental.EditorVR
 			{
 				var alternateMenu = deviceData.alternateMenu;
 				var flags = deviceData.menuHideFlags[alternateMenu];
-				Debug.LogError(deviceData.node + " : <color=orange>AlternateMenu hide flags: </color>" + deviceData.menuHideFlags[alternateMenu]);
 				if ((flags & MenuHideFlags.OpaqueReveal) != 0)
 				{
-					Debug.LogError("<color=yellow>AlternateMenu hide flags: </color>" + deviceData.menuHideFlags[alternateMenu]);
-					deviceData.menuHideFlags[alternateMenu] &= ~MenuHideFlags.OpaqueReveal;
-					deviceData.menuHideFlags[alternateMenu] &= ~MenuHideFlags.Hidden;
-
-					if (alternateMenu.visible)
-						alternateMenu.opaqueReveal = true;
-
-					Debug.LogError("<color=green>AlternateMenu hide flags: </color>" + deviceData.menuHideFlags[alternateMenu]);
+					deviceData.menuHideFlags[alternateMenu] &= ~(MenuHideFlags.OpaqueReveal | MenuHideFlags.Hidden);
+					alternateMenu.opaqueReveal = true;
 				}
 
 				alternateMenu.visible = deviceData.menuHideFlags[alternateMenu] == 0 && !(deviceData.currentTool is IExclusiveMode);
@@ -261,9 +254,10 @@ namespace UnityEditor.Experimental.EditorVR
 					if (alternateMenu != null)
 					{
 						var flags = deviceData.menuHideFlags[alternateMenu];
-						deviceData.menuHideFlags[alternateMenu] = (deviceData.rayOrigin == rayOrigin) && visible ? flags & ~MenuHideFlags.Hidden : flags | MenuHideFlags.Hidden;
+						var visibileDevice = (deviceData.rayOrigin == rayOrigin) && visible;
+						deviceData.menuHideFlags[alternateMenu] = visibileDevice ? flags & ~MenuHideFlags.Hidden : flags | MenuHideFlags.Hidden;
 
-						if (opaqueReveal && visible && deviceData.rayOrigin == rayOrigin)
+						if (opaqueReveal && visibileDevice)
 							deviceData.menuHideFlags[alternateMenu] = flags | MenuHideFlags.OpaqueReveal;
 					}
 				});

--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -172,7 +172,7 @@ namespace UnityEditor.Experimental.EditorVR
 			m_ActionsModule = AddModule<ActionsModule>();
 
 			m_LockModule = AddModule<LockModule>();
-			m_LockModule.updateAlternateMenu = (rayOrigin, o) => m_Menus.SetAlternateMenuVisibility(rayOrigin, o != null);
+			m_LockModule.updateAlternateMenu = (rayOrigin, o, opaqueReveal) => m_Menus.SetAlternateMenuVisibility(rayOrigin, o != null, opaqueReveal);
 
 			m_SelectionModule = AddModule<SelectionModule>();
 			m_SelectionModule.selected += m_Rays.SetLastSelectionRayOrigin; // when a selection occurs in the selection tool, call show in the alternate menu, allowing it to show/hide itself.

--- a/Scripts/Interfaces/IAlternateMenu.cs
+++ b/Scripts/Interfaces/IAlternateMenu.cs
@@ -15,8 +15,8 @@ namespace UnityEditor.Experimental.EditorVR
 		event Action<Transform> itemWasSelected;
 
 		/// <summary>
-		/// If true the menu will maintain visibilty when being revealed/shown
-		/// Used when unlocking objects, in order to maintain full menu opacity for a period of time
+		/// If true the menu will maintain fully-opaque visibilty for a period of time when revealed
+		/// Used when unlocking objects, in order to maintain full menu opacity for a period of time, drawing attention to the menu
 		/// </summary>
 		bool opaqueReveal { set; }
 	}

--- a/Scripts/Interfaces/IAlternateMenu.cs
+++ b/Scripts/Interfaces/IAlternateMenu.cs
@@ -13,6 +13,12 @@ namespace UnityEditor.Experimental.EditorVR
 		/// Delegate called when any item was selected in the alternate menu
 		/// </summary>
 		event Action<Transform> itemWasSelected;
+
+		/// <summary>
+		/// If true the menu will maintain visibilty when being revealed/shown
+		/// Used when unlocking objects, in order to maintain full menu opacity for a period of time
+		/// </summary>
+		bool opaqueReveal { set; }
 	}
 }
 #endif

--- a/Scripts/Modules/Lock/LockModule.cs
+++ b/Scripts/Modules/Lock/LockModule.cs
@@ -30,7 +30,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
 		// TODO: This should go away once the alternate menu stays open or if locking/unlocking from alternate menu goes 
 		// away entirely (e.g. because of HierarchyWorkspace)
-		public Action<Transform, GameObject> updateAlternateMenu { private get; set; }
+		public Action<Transform, GameObject, bool> updateAlternateMenu { private get; set; }
 
 		readonly List<GameObject> m_LockedGameObjects = new List<GameObject>();
 
@@ -104,7 +104,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 				{
 					// Turn off menu if it was previously shown
 					if (IsLocked(m_CurrentHoverObject))
-						updateAlternateMenu(rayOrigin, null);
+						updateAlternateMenu(rayOrigin, null, false);
 
 					m_HoverRayOrigin = null;
 					m_CurrentHoverObject = null;
@@ -119,14 +119,15 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 						UpdateAction(go);
 
 						// Open up the menu, so that locking can be changed
-						updateAlternateMenu(rayOrigin, go);
+						updateAlternateMenu(rayOrigin, go, true);
+						m_HoverDuration = 0f;
 					}
 				}
 				else // Switch to new hover object on the same ray origin
 				{
 					// Turn off menu if it was previously shown
 					if (IsLocked(m_CurrentHoverObject))
-						updateAlternateMenu(rayOrigin, null);
+						updateAlternateMenu(rayOrigin, null, false);
 
 					m_CurrentHoverObject = go;
 					m_HoverDuration = 0f;


### PR DESCRIPTION
- In addition, fixed Radial Menu icon rotation when being revealed in certain cases.