### PR TITLE
Fix incorrect initial RadialMenu icon rotation when revealing

### DIFF
--- a/Menus/RadialMenu/Scripts/RadialMenuSlot.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuSlot.cs
@@ -244,7 +244,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 			ObjectUtils.Destroy(m_FrameMaterial);
 		}
 
-		void CorrectIconRotation()
+		public void CorrectIconRotation()
 		{
 			m_IconLookDirection = m_Icon.transform.position + transform.parent.forward * m_IconLookForwardOffset; // set a position offset above the icon, regardless of the icon's rotation
 			m_IconContainer.LookAt(m_IconLookDirection);

--- a/Menus/RadialMenu/Scripts/RadialMenuUI.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuUI.cs
@@ -289,7 +289,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 				for (int i = 0; i < m_RadialMenuSlots.Count; ++i)
 				{
 					if (i < m_Actions.Count)
+					{
 						m_RadialMenuSlots[i].transform.localRotation = Quaternion.Lerp(hiddenSlotRotation, m_RadialMenuSlots[i].visibleLocalRotation, revealAmount * revealAmount);
+						m_RadialMenuSlots[i].CorrectIconRotation();
+					}
 				}
 
 				yield return null;


### PR DESCRIPTION
Fix incorrect initial RadialMenu icon rotation when hiding then showing the RadialMenu.  This fix was included in the radial menu opacity pulse PR that was closed, but is still needed in development.