### PR TITLE
Fix OnHierarchyChanged spam while MiniWorld is open

### DIFF
--- a/Manipulators/BaseManipulator.cs
+++ b/Manipulators/BaseManipulator.cs
@@ -6,18 +6,21 @@ namespace UnityEditor.Experimental.EditorVR.Manipulators
 {
 	class BaseManipulator : MonoBehaviour, IManipulator
 	{
-		public bool dragging { get; protected set; }
-
 		protected const float k_BaseManipulatorSize = 0.3f;
+
+		public bool adjustScaleForCamera { get; set; }
 
 		public Action<Vector3> translate { protected get; set; }
 		public Action<Quaternion> rotate { protected get; set; }
 		public Action<Vector3> scale { protected get; set; }
+		public bool dragging { get; protected set; }
+
 		public event Action dragStarted;
 
 		protected virtual void OnEnable()
 		{
-			Camera.onPreRender += OnCameraPreRender;
+			if (adjustScaleForCamera)
+				Camera.onPreRender += OnCameraPreRender;
 		}
 
 		protected virtual void OnDisable()

--- a/Manipulators/ScaleManipulator.prefab
+++ b/Manipulators/ScaleManipulator.prefab
@@ -60,7 +60,7 @@ GameObject:
   - 114: {fileID: 114000013616855498}
   m_Layer: 5
   m_Name: ScaleManipulator
-  m_TagString: ShowInMiniWorld
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -543,6 +543,7 @@ MonoBehaviour:
   m_RunInEditMode: 0
   m_SelectionFlags: 3
   m_HandleTip: {fileID: 0}
+  m_OrientDragPlaneToRay: 1
 --- !u!114 &114000011147854508
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -557,6 +558,7 @@ MonoBehaviour:
   m_RunInEditMode: 0
   m_SelectionFlags: 3
   m_HandleTip: {fileID: 4000011529957722}
+  m_OrientDragPlaneToRay: 1
 --- !u!114 &114000011988091676
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -571,6 +573,7 @@ MonoBehaviour:
   m_RunInEditMode: 0
   m_SelectionFlags: 3
   m_HandleTip: {fileID: 4000012243801892}
+  m_OrientDragPlaneToRay: 1
 --- !u!114 &114000013052707070
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -585,6 +588,7 @@ MonoBehaviour:
   m_RunInEditMode: 0
   m_SelectionFlags: 3
   m_HandleTip: {fileID: 4000012628356964}
+  m_OrientDragPlaneToRay: 1
 --- !u!114 &114000013616855498
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Scripts/Core/EditorVR.MiniWorlds.cs
+++ b/Scripts/Core/EditorVR.MiniWorlds.cs
@@ -65,7 +65,7 @@ namespace UnityEditor.Experimental.EditorVR
 			/// <summary>
 			/// Re-use DefaultProxyRay and strip off objects and components not needed for MiniWorldRays
 			/// </summary>
-			internal Transform InstantiateMiniWorldRay()
+			static Transform InstantiateMiniWorldRay()
 			{
 				var miniWorldRay = ObjectUtils.Instantiate(evr.m_ProxyRayPrefab.gameObject).transform;
 				ObjectUtils.Destroy(miniWorldRay.GetComponent<DefaultProxyRay>());

--- a/Scripts/Core/EditorVR.MiniWorlds.cs
+++ b/Scripts/Core/EditorVR.MiniWorlds.cs
@@ -57,7 +57,6 @@ namespace UnityEditor.Experimental.EditorVR
 				EditorApplication.hierarchyWindowChanged -= OnHierarchyChanged;
 			}
 
-			// TODO: Find a better callback for when objects are created or destroyed
 			void OnHierarchyChanged()
 			{
 				m_MiniWorldIgnoreListDirty = true;

--- a/Scripts/Core/EditorVR.Rays.cs
+++ b/Scripts/Core/EditorVR.Rays.cs
@@ -324,13 +324,13 @@ namespace UnityEditor.Experimental.EditorVR
 				if (!m_StandardManipulator)
 					m_StandardManipulator = evr.GetComponentInChildren<StandardManipulator>();
 
-				if (m_StandardManipulator)
+				if (m_StandardManipulator && m_StandardManipulator.adjustScaleForCamera)
 					m_StandardManipulator.AdjustScale(cameraPosition, matrix);
 
 				if (!m_ScaleManipulator)
 					m_ScaleManipulator = evr.GetComponentInChildren<ScaleManipulator>();
 
-				if (m_ScaleManipulator)
+				if (m_ScaleManipulator && m_ScaleManipulator.adjustScaleForCamera)
 					m_ScaleManipulator.AdjustScale(cameraPosition, matrix);
 			}
 		}

--- a/Tools/TransformTool/TransformTool.cs
+++ b/Tools/TransformTool/TransformTool.cs
@@ -475,12 +475,22 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 		{
 			var go = ObjectUtils.Instantiate(prefab, transform, active: false);
 			go.SetActive(false);
+			HideGameObjectRecursively(go); // MiniWorld constantly modifies manipulator, triggering OnHierarchyChanged
 			var manipulator = go.GetComponent<BaseManipulator>();
 			manipulator.translate = Translate;
 			manipulator.rotate = Rotate;
 			manipulator.scale = Scale;
 			manipulator.dragStarted += OnDragStarted;
 			return manipulator;
+		}
+
+		static void HideGameObjectRecursively(GameObject go)
+		{
+			go.hideFlags |= HideFlags.HideInHierarchy;
+			foreach (Transform child in go.transform)
+			{
+				HideGameObjectRecursively(child.gameObject);
+			}
 		}
 
 		private void UpdateCurrentManipulator()

--- a/Tools/TransformTool/TransformTool.cs
+++ b/Tools/TransformTool/TransformTool.cs
@@ -446,17 +446,17 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 			showDefaultRay(grabData.rayOrigin, true);
 		}
 
-		private void Translate(Vector3 delta)
+		void Translate(Vector3 delta)
 		{
 			m_TargetPosition += delta;
 		}
 
-		private void Rotate(Quaternion delta)
+		void Rotate(Quaternion delta)
 		{
 			m_TargetRotation = delta * m_TargetRotation;
 		}
 
-		private void Scale(Vector3 delta)
+		void Scale(Vector3 delta)
 		{
 			m_TargetScale += delta;
 		}
@@ -466,7 +466,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 			Undo.IncrementCurrentGroup();
 		}
 
-		private void UpdateSelectionBounds()
+		void UpdateSelectionBounds()
 		{
 			m_SelectionBounds = ObjectUtils.GetBounds(Selection.gameObjects);
 		}
@@ -475,7 +475,6 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 		{
 			var go = ObjectUtils.Instantiate(prefab, transform, active: false);
 			go.SetActive(false);
-			HideGameObjectRecursively(go); // MiniWorld constantly modifies manipulator, triggering OnHierarchyChanged
 			var manipulator = go.GetComponent<BaseManipulator>();
 			manipulator.translate = Translate;
 			manipulator.rotate = Rotate;
@@ -484,16 +483,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 			return manipulator;
 		}
 
-		static void HideGameObjectRecursively(GameObject go)
-		{
-			go.hideFlags |= HideFlags.HideInHierarchy;
-			foreach (Transform child in go.transform)
-			{
-				HideGameObjectRecursively(child.gameObject);
-			}
-		}
-
-		private void UpdateCurrentManipulator()
+		void UpdateCurrentManipulator()
 		{
 			var selectionTransforms = Selection.transforms;
 			if (selectionTransforms.Length <= 0)

--- a/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs
+++ b/Workspaces/MiniWorld/Scripts/MiniWorldRenderer.cs
@@ -79,8 +79,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				m_MiniCamera.cameraType = CameraType.Game;
 				m_MiniCamera.clearFlags = CameraClearFlags.Nothing;
 				m_MiniCamera.worldToCameraMatrix = GetWorldToCameraMatrix(camera);
+
 				var referenceBounds = miniWorld.referenceBounds;
 				var inverseRotation = Quaternion.Inverse(miniWorld.referenceTransform.rotation);
+
 				Shader.SetGlobalVector("_GlobalClipCenter", inverseRotation * referenceBounds.center);
 				Shader.SetGlobalVector("_GlobalClipExtents", referenceBounds.extents);
 				Shader.SetGlobalMatrix("_InverseRotation", Matrix4x4.TRS(Vector3.zero, inverseRotation, Vector3.one));
@@ -88,7 +90,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				for (var i = 0; i < m_IgnoreList.Count; i++)
 				{
 					var hiddenRenderer = m_IgnoreList[i];
-					if (!hiddenRenderer)
+					if (!hiddenRenderer || !hiddenRenderer.gameObject.activeInHierarchy)
 						continue;
 
 					if (hiddenRenderer.CompareTag(ShowInMiniWorldTag))
@@ -109,13 +111,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				for (var i = 0; i < m_IgnoreList.Count; i++)
 				{
 					var hiddenRenderer = m_IgnoreList[i];
-					if (!hiddenRenderer)
+					if (!hiddenRenderer || !hiddenRenderer.gameObject.activeInHierarchy)
 						continue;
 
 					if (hiddenRenderer.CompareTag(ShowInMiniWorldTag))
 						hiddenRenderer.gameObject.layer = m_IgnoredObjectLayer[i];
 					else
-						m_IgnoreList[i].enabled = m_IgnoreObjectRendererEnabled[i];
+						hiddenRenderer.enabled = m_IgnoreObjectRendererEnabled[i];
 				}
 			}
 		}


### PR DESCRIPTION
We noticed this a while ago when refactoring how ignore lists worked. We added a feature to only update ignore lists for minworlds and the pixel raycast module when the hierachy changes. But, it turned out that OnHierarchyChanged gets called a lot. Currently, it is called every frame while the MiniWorld is open because of changes to the manipulator.  This change stops the spam.

I would like to know more about why this happens only when MiniWorld is open and because of the Manipulator, but I couldn't find a sensible way to debug the source of the change in managed code. I tracked it down to the manipulator by setting a native breakpoint and reading the name of the transform responsible.