### PR TITLE
Remove unused using causing compilation errors when SteamVR isn't installed

### DIFF
--- a/Workspaces/ProjectWorkspace/ProjectWorkspace.cs
+++ b/Workspaces/ProjectWorkspace/ProjectWorkspace.cs
@@ -7,7 +7,6 @@ using UnityEditor.Experimental.EditorVR.Handles;
 using UnityEditor.Experimental.EditorVR.UI;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
-using Valve.VR.InteractionSystem;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {


### PR DESCRIPTION
When testing development without SteamVR installed, this exception presented itself.  Quick fix; just removed the already unused Valve.VR.InteractionSystem.