### PR TITLE
Fix UI control blocking

### DIFF
--- a/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
+++ b/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
@@ -149,7 +149,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 				if (!sourceAMI.active)
 				{
 					// If we have an object, the ray is blocked--input should not bleed through
-					if (hasObject)
+					if (hasObject && select.wasJustReleased)
 						consumeControl(select);
 
 					continue;

--- a/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
+++ b/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
@@ -149,7 +149,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 				if (!sourceAMI.active)
 				{
 					// If we have an object, the ray is blocked--input should not bleed through
-					if (hasObject && select.wasJustReleased)
+					if (hasObject && select.wasJustPressed)
 						consumeControl(select);
 
 					continue;


### PR DESCRIPTION
We were consuming the select control prematurely in MultipleRayInputModule, which caused things that rely on isHeld like the WorkspaceMoveTool to break.

This PR only consumes the select control when the trigger is pressed.