### PR TITLE
Fix dropping objects from project into miniworld

### DIFF
--- a/Scripts/Core/EditorVR.Rays.cs
+++ b/Scripts/Core/EditorVR.Rays.cs
@@ -159,21 +159,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 									deviceData.directSelectInput = deviceInputModule.CreateActionMapInput(deviceInputModule.directSelectActionMap, device);
 
 									// Add RayOrigin transform, proxy and ActionMapInput references to input module list of sources
-									inputModule.AddRaycastSource(proxy, node, deviceData.uiInput, rayOriginPair.Value, source =>
-									{
-										var miniWorlds = evr.m_MiniWorlds.worlds;
-										foreach (var miniWorld in miniWorlds)
-										{
-											var targetObject = source.hoveredObject ? source.hoveredObject : source.draggedObject;
-											if (miniWorld.Contains(source.rayOrigin.position))
-											{
-												if (targetObject && !targetObject.transform.IsChildOf(miniWorld.miniWorldTransform.parent))
-													return false;
-											}
-										}
-
-										return true;
-									});
+									inputModule.AddRaycastSource(proxy, node, deviceData.uiInput, rayOriginPair.Value);
 								}
 							}
 

--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -190,7 +190,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			UnityBrandColorScheme.sessionGradient = UnityBrandColorScheme.GetRandomGradient();
 
 			var sceneObjectModule = AddModule<SceneObjectModule>();
-			sceneObjectModule.shouldPlaceObject = (obj, targetScale) =>
+			sceneObjectModule.tryPlaceObject = (obj, targetScale) =>
 			{
 				foreach (var miniWorld in m_MiniWorlds.worlds)
 				{
@@ -202,6 +202,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 					obj.position = referenceTransform.position + Vector3.Scale(miniWorld.miniWorldTransform.InverseTransformPoint(obj.position), miniWorld.referenceTransform.localScale);
 					obj.rotation = referenceTransform.rotation * Quaternion.Inverse(miniWorld.miniWorldTransform.rotation) * obj.rotation;
 					obj.localScale = Vector3.Scale(Vector3.Scale(obj.localScale, referenceTransform.localScale), miniWorld.miniWorldTransform.lossyScale);
+
+					spatialHashModule.AddObject(obj.gameObject);
 					return false;
 				}
 

--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -204,10 +204,10 @@ namespace UnityEditor.Experimental.EditorVR.Core
 					obj.localScale = Vector3.Scale(Vector3.Scale(obj.localScale, referenceTransform.localScale), miniWorld.miniWorldTransform.lossyScale);
 
 					spatialHashModule.AddObject(obj.gameObject);
-					return false;
+					return true;
 				}
 
-				return true;
+				return false;
 			};
 
 			m_Viewer.AddPlayerModel();

--- a/Scripts/Modules/SceneObjectModule.cs
+++ b/Scripts/Modules/SceneObjectModule.cs
@@ -11,11 +11,11 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 		const float k_InstantiateFOVDifference = -5f;
 		const float k_GrowDuration = 0.5f;
 
-		public Func<Transform, Vector3, bool> shouldPlaceObject;
+		public Func<Transform, Vector3, bool> tryPlaceObject;
 
 		public void PlaceSceneObject(Transform obj, Vector3 targetScale)
 		{
-			if (shouldPlaceObject == null || shouldPlaceObject(obj, targetScale))
+			if (tryPlaceObject == null || tryPlaceObject(obj, targetScale))
 				StartCoroutine(PlaceSceneObjectCoroutine(obj, targetScale));
 		}
 

--- a/Scripts/Modules/SceneObjectModule.cs
+++ b/Scripts/Modules/SceneObjectModule.cs
@@ -15,7 +15,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
 		public void PlaceSceneObject(Transform obj, Vector3 targetScale)
 		{
-			if (tryPlaceObject == null || tryPlaceObject(obj, targetScale))
+			if (tryPlaceObject == null || !tryPlaceObject(obj, targetScale))
 				StartCoroutine(PlaceSceneObjectCoroutine(obj, targetScale));
 		}
 

--- a/Scripts/Modules/SnappingModule/SnappingModule.cs
+++ b/Scripts/Modules/SnappingModule/SnappingModule.cs
@@ -469,7 +469,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			var maxRayLength = k_SurfaceSnappingMaxRayLength * this.GetViewerScale();
 
 			var pointerRay = new Ray(rayOrigin.position, rayOrigin.forward);
-			return SnapToSurface(pointerRay, ref position, ref rotation, state, offset, targetPosition, targetRotation , rotationOffset, upVector, m_CombinedIgnoreList, breakDistance, maxRayLength)
+			return SnapToSurface(pointerRay, ref position, ref rotation, state, offset, targetPosition, targetRotation , rotationOffset, upVector, breakDistance, maxRayLength)
 				|| TryBreakSurfaceSnap(ref position, ref rotation, targetPosition, startRotation, state, breakDistance);
 		}
 
@@ -494,7 +494,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 				else
 					offset += projectedExtents;
 
-				if (SnapToSurface(boundsRay, ref position, ref rotation, state, offset, targetPosition, targetRotation, rotationOffset, upVector, m_CombinedIgnoreList, breakDistance, raycastDistance))
+				if (SnapToSurface(boundsRay, ref position, ref rotation, state, offset, targetPosition, targetRotation, rotationOffset, upVector, breakDistance, raycastDistance))
 					return true;
 			}
 
@@ -532,7 +532,11 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
 			for (int i = 0; i < objects.Length; i++)
 			{
-				m_CombinedIgnoreList.Add(objects[i]);
+				var renderers = objects[i].GetComponentsInChildren<Renderer>();
+				for (var j = 0; j < renderers.Length; j++)
+				{
+					m_CombinedIgnoreList.Add(renderers[j].gameObject);
+				}
 			}
 
 			for (int i = 0; i < ignoreList.Length; i++)
@@ -541,11 +545,11 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			}
 		}
 
-		bool SnapToSurface(Ray ray, ref Vector3 position, ref Quaternion rotation, SnappingState state, Vector3 boundsOffset, Vector3 targetPosition, Quaternion targetRotation, Quaternion rotationOffset, Vector3 upVector, List<GameObject> ignoreList, float breakDistance, float raycastDistance)
+		bool SnapToSurface(Ray ray, ref Vector3 position, ref Quaternion rotation, SnappingState state, Vector3 boundsOffset, Vector3 targetPosition, Quaternion targetRotation, Quaternion rotationOffset, Vector3 upVector, float breakDistance, float raycastDistance)
 		{
 			RaycastHit hit;
 			GameObject go;
-			if (raycast(ray, out hit, out go, raycastDistance, ignoreList))
+			if (raycast(ray, out hit, out go, raycastDistance, m_CombinedIgnoreList))
 			{
 				var snappedRotation = Quaternion.LookRotation(hit.normal, upVector) * rotationOffset;
 


### PR DESCRIPTION
Closes #121

A lot of this was just clean up of miniworld interactions that have changed as a result of other features.

The isValid check was hard to track down, but was originally put there because pan/zoom actions were interfering with manipulating things in the miniworld.

I also noticed a snapping bug when using certain assets and fixed it.