### PR TITLE
Fix camera clip planes on deserialized scales

### DIFF
--- a/Scripts/Core/EditorVR.Viewer.cs
+++ b/Scripts/Core/EditorVR.Viewer.cs
@@ -37,6 +37,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			const float k_CameraRigTransitionTime = 0.75f;
 
 			PlayerBody m_PlayerBody;
+			float m_OriginalNearClipPlane;
+			float m_OriginalFarClipPlane;
 
 			readonly Preferences m_Preferences = new Preferences();
 
@@ -52,6 +54,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 				IUsesViewerBodyMethods.isOverShoulder = IsOverShoulder;
 				IUsesViewerBodyMethods.isAboveHead = IsAboveHead;
 				IUsesViewerScaleMethods.getViewerScale = GetViewerScale;
+				IUsesViewerScaleMethods.setViewerScale = SetViewerScale;
 
 				VRView.hmdStatusChange += OnHMDStatusChange;
 
@@ -131,7 +134,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 				var inverseRotation = Quaternion.Inverse(cameraRotation);
 				cameraRig.position = Vector3.zero;
 				cameraRig.rotation = inverseRotation * preferences.cameraRotation;
-				cameraRig.localScale = Vector3.one * preferences.cameraRigScale;
+				SetViewerScale(preferences.cameraRigScale);
 				cameraRig.position = preferences.cameraPosition - cameraTransform.position;
 			}
 
@@ -142,6 +145,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 				cameraRig.hideFlags = defaultHideFlags;
 				var viewerCamera = CameraUtils.GetMainCamera();
 				viewerCamera.gameObject.hideFlags = defaultHideFlags;
+				m_OriginalNearClipPlane = viewerCamera.nearClipPlane;
+				m_OriginalFarClipPlane = viewerCamera.farClipPlane;
 				if (VRSettings.loadedDeviceName == "OpenVR")
 				{
 					// Steam's reference position should be at the feet and not at the head as we do with Oculus
@@ -280,6 +285,14 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			internal static float GetViewerScale()
 			{
 				return CameraUtils.GetCameraRig().localScale.x;
+			}
+
+			void SetViewerScale(float scale)
+			{
+				var camera = CameraUtils.GetMainCamera();
+				CameraUtils.GetCameraRig().localScale = Vector3.one * scale;
+				camera.nearClipPlane = m_OriginalNearClipPlane * scale;
+				camera.farClipPlane = m_OriginalFarClipPlane * scale;
 			}
 		}
 	}

--- a/Scripts/Interfaces/IUsesViewerScale.cs
+++ b/Scripts/Interfaces/IUsesViewerScale.cs
@@ -9,7 +9,9 @@ namespace UnityEditor.Experimental.EditorVR
 
 	public static class IUsesViewerScaleMethods
 	{
+
 		internal static Func<float> getViewerScale { get; set; }
+		internal static Action<float> setViewerScale { get; set; }
 
 		/// <summary>
 		/// Returns whether the specified transform is over the viewer's shoulders and behind the head
@@ -17,6 +19,15 @@ namespace UnityEditor.Experimental.EditorVR
 		public static float GetViewerScale(this IUsesViewerScale obj)
 		{
 			return getViewerScale();
+		}
+
+		/// <summary>
+		/// Set the scale of the viewer object
+		/// </summary>
+		/// <param name="scale">Uniform scale value in world space</param>
+		public static void SetViewerScale(this IUsesViewerScale obj, float scale)
+		{
+			setViewerScale(scale);
 		}
 	}
 }

--- a/Tools/BlinkLocomotionTool/BlinkLocomotionTool.cs
+++ b/Tools/BlinkLocomotionTool/BlinkLocomotionTool.cs
@@ -71,10 +71,6 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 		[SerializeField]
 		private ActionMap m_BlinkActionMap;
 
-		Camera m_MainCamera;
-		float m_OriginalNearClipPlane;
-		float m_OriginalFarClipPlane;
-
 		public Transform rayOrigin { private get; set; }
 		public Node? node { private get; set; }
 
@@ -93,10 +89,6 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 			m_BlinkVisualsGO.transform.parent = rayOrigin;
 			m_BlinkVisualsGO.transform.localPosition = Vector3.zero;
 			m_BlinkVisualsGO.transform.localRotation = Quaternion.identity;
-
-			m_MainCamera = CameraUtils.GetMainCamera();
-			m_OriginalNearClipPlane = m_MainCamera.nearClipPlane;
-			m_OriginalFarClipPlane = m_MainCamera.farClipPlane;
 
 			Shader.SetGlobalFloat(k_WorldScaleProperty, 1);
 		}
@@ -192,12 +184,9 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 									rayToRay = otherRayOrigin.position - rayOrigin.position;
 									midPoint = rayOrigin.position + rayToRay * 0.5f;
 									var currOffset = midPoint - cameraRig.position;
-									cameraRig.localScale = Vector3.one;
+									this.SetViewerScale(1f);
 									cameraRig.position = midPoint - currOffset / currentScale;
 									cameraRig.rotation = Quaternion.AngleAxis(m_StartYaw, Vector3.up);
-
-									m_MainCamera.nearClipPlane = m_OriginalNearClipPlane;
-									m_MainCamera.farClipPlane = m_OriginalFarClipPlane;
 
 									consumeControl(m_Thumb);
 									consumeControl(blinkTool.m_Thumb);
@@ -220,11 +209,9 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 									midPoint = currentRotation * midPoint * currentScale;
 
 									cameraRig.position = m_StartPosition + m_StartMidPoint - midPoint;
-									cameraRig.localScale = Vector3.one * currentScale;
 									cameraRig.rotation = currentRotation;
 
-									m_MainCamera.nearClipPlane = m_OriginalNearClipPlane * currentScale;
-									m_MainCamera.farClipPlane = m_OriginalFarClipPlane * currentScale;
+									this.SetViewerScale(currentScale);
 
 									m_ViewerScaleVisuals.viewerScale = currentScale;
 									m_BlinkVisuals.viewerScale = currentScale;


### PR DESCRIPTION
As I was messing around with the Console Workspace, I found that the face of the workspace had a lot of z-fighting artifacts when starting EVR after it deserializes a very large viewer scale. The issue was that we were just setting the camera rig scale and not the clip planes.

I added SetViewerScale to IUsesViewerScale and put the clip plane logic in EditorVR.Viewer, that way we just call SetViewerScale everywhere and it will set the scale and the clip planes.