### PR TITLE
Fix missing workspace UI highlight states

### DIFF
--- a/Workspaces/HierarchyWorkspace/Prefabs/CreateEmptyUI.prefab
+++ b/Workspaces/HierarchyWorkspace/Prefabs/CreateEmptyUI.prefab
@@ -290,6 +290,7 @@ MonoBehaviour:
   m_SwapIconsOnClick: 1
   m_HighlightItems:
   - {fileID: 114000013561299652}
+  - {fileID: 114000013733206062}
   m_GrayscaleGradient: 0
   m_AnimatedReveal: 0
   m_DelayBeforeReveal: 0.5

--- a/Workspaces/HierarchyWorkspace/Prefabs/FocusUI.prefab
+++ b/Workspaces/HierarchyWorkspace/Prefabs/FocusUI.prefab
@@ -290,6 +290,7 @@ MonoBehaviour:
   m_SwapIconsOnClick: 1
   m_HighlightItems:
   - {fileID: 114000012074414550}
+  - {fileID: 114000011088997820}
   m_GrayscaleGradient: 0
   m_AnimatedReveal: 0
   m_DelayBeforeReveal: 0.5

--- a/Workspaces/LockedObjectsWorkspace/Prefabs/UnlockAllUI.prefab
+++ b/Workspaces/LockedObjectsWorkspace/Prefabs/UnlockAllUI.prefab
@@ -231,6 +231,7 @@ MonoBehaviour:
   m_SwapIconsOnClick: 1
   m_HighlightItems:
   - {fileID: 114000012074414550}
+  - {fileID: 114000011088997820}
   m_GrayscaleGradient: 0
   m_AnimatedReveal: 0
   m_DelayBeforeReveal: 0.5


### PR DESCRIPTION
The text elements in the CreateEmptyUI, FocusUI, and UnlockAllUI were not assigned as highlight elements, and weren't reflecting the expected highlight state (inverse)color change that other UI elements display correctly.