### PR TITLE
Revive workspace highlight on drag + resize

### DIFF
--- a/Workspaces/Base/WorkspaceUI.cs
+++ b/Workspaces/Base/WorkspaceUI.cs
@@ -628,6 +628,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 						var direction = GetResizeDirectionForLocalPosition(localPosition);
 						GetResizeIconForDirection(direction);
 					}
+
+					highlightsVisible = false;
 				}
 				else
 				{
@@ -749,6 +751,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				{
 					smoothMotion.enabled = false;
 				}
+
+				highlightsVisible = true;
 			}
 		}
 


### PR DESCRIPTION
Fix missing workspace highlight on drag + resize; enabling/disabling was lost during recent workspace drag/resize changes.