### PR TITLE
List View Event Ordering

### DIFF
--- a/Scripts/ListView/ListViewController.cs
+++ b/Scripts/ListView/ListViewController.cs
@@ -55,13 +55,14 @@ namespace ListView
 			var doneSettling = true;
 
 			var offset = 0f;
+			var order = 0;
 			for (int i = 0; i < m_Data.Count; i++)
 			{
 				var datum = m_Data[i];
 				if (offset + scrollOffset + itemSize.z < 0 || offset + scrollOffset > m_Size.z)
 					Recycle(datum.index);
 				else
-					UpdateVisibleItem(datum, i * itemSize.z + m_ScrollOffset, ref doneSettling);
+					UpdateVisibleItem(datum, order++, i * itemSize.z + m_ScrollOffset, ref doneSettling);
 
 				offset += itemSize.z;
 			}
@@ -92,7 +93,7 @@ namespace ListView
 			item.gameObject.SetActive(false);
 		}
 
-		protected virtual void UpdateVisibleItem(TData data, float offset, ref bool doneSettling)
+		protected virtual void UpdateVisibleItem(TData data, int order, float offset, ref bool doneSettling)
 		{
 			TItem item;
 			var index = data.index;
@@ -102,7 +103,7 @@ namespace ListView
 				m_ListItems[index] = item;
 			}
 
-			UpdateItem(item.transform, offset, ref doneSettling);
+			UpdateItem(item.transform, order, offset, ref doneSettling);
 		}
 
 		protected virtual void SetRowGrabbed(TIndex index, Transform rayOrigin, bool grabbed)

--- a/Scripts/ListView/ListViewControllerBase.cs
+++ b/Scripts/ListView/ListViewControllerBase.cs
@@ -158,14 +158,14 @@ namespace ListView
 			m_ScrollOffset = index * itemSize.z;
 		}
 
-		protected virtual void UpdateItem(Transform t, float offset, ref bool doneSettling)
+		protected virtual void UpdateItem(Transform t, int order, float offset, ref bool doneSettling)
 		{
 			var targetPosition = m_StartPosition + offset * Vector3.back;
 			var targetRotation = Quaternion.identity;
-			UpdateItemTransform(t, targetPosition, targetRotation, false, ref doneSettling);
+			UpdateItemTransform(t, order, targetPosition, targetRotation, false, ref doneSettling);
 		}
 
-		protected virtual void UpdateItemTransform(Transform t, Vector3 targetPosition, Quaternion targetRotation, bool dontSettle, ref bool doneSettling)
+		protected virtual void UpdateItemTransform(Transform t, int order, Vector3 targetPosition, Quaternion targetRotation, bool dontSettle, ref bool doneSettling)
 		{
 			if (m_Settling && !dontSettle)
 			{
@@ -182,6 +182,8 @@ namespace ListView
 				t.localPosition = targetPosition;
 				t.localRotation = targetRotation;
 			}
+
+			t.SetSiblingIndex(order);
 		}
 
 		protected virtual Vector3 GetObjectSize(GameObject g)

--- a/Workspaces/Common/Scripts/NestedListViewController.cs
+++ b/Workspaces/Common/Scripts/NestedListViewController.cs
@@ -69,15 +69,16 @@ namespace ListView
 		{
 			var doneSettling = true;
 			var count = 0f;
+			var order = 0;
 
-			UpdateRecursively(m_Data, ref count, ref doneSettling);
+			UpdateRecursively(m_Data, ref order, ref count, ref doneSettling);
 			m_ExpandedDataLength = count;
 
 			if (m_Settling && doneSettling)
 				EndSettling();
 		}
 
-		protected virtual void UpdateRecursively(List<TData> data, ref float offset, ref bool doneSettling, int depth = 0)
+		protected virtual void UpdateRecursively(List<TData> data, ref int order, ref float offset, ref bool doneSettling, int depth = 0)
 		{
 			for (int i = 0; i < data.Count; i++)
 			{
@@ -93,23 +94,23 @@ namespace ListView
 				if (offset + scrollOffset + itemSize.z < 0 || offset + scrollOffset > m_Size.z)
 					Recycle(index);
 				else
-					UpdateNestedItem(datum, offset, depth, ref doneSettling);
+					UpdateNestedItem(datum, order++, offset, depth, ref doneSettling);
 
 				offset += itemSize.z;
 
 				if (datum.children != null)
 				{
 					if (expanded)
-						UpdateRecursively(datum.children, ref offset, ref doneSettling, depth + 1);
+						UpdateRecursively(datum.children, ref order, ref offset, ref doneSettling, depth + 1);
 					else
 						RecycleChildren(datum);
 				}
 			}
 		}
 
-		protected virtual void UpdateNestedItem(TData data, float count, int depth, ref bool doneSettling)
+		protected virtual void UpdateNestedItem(TData data, int order, float count, int depth, ref bool doneSettling)
 		{
-			UpdateVisibleItem(data, count, ref doneSettling);
+			UpdateVisibleItem(data, order, count, ref doneSettling);
 		}
 
 		protected void RecycleChildren(TData data)

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListViewController.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListViewController.cs
@@ -127,7 +127,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			}
 		}
 
-		void UpdateHierarchyItem(HierarchyData data, ref float offset, int depth, bool? expanded, ref bool doneSettling)
+		void UpdateHierarchyItem(HierarchyData data, int order, ref float offset, int depth, bool? expanded, ref bool doneSettling)
 		{
 			var index = data.index;
 			HierarchyListItem item;
@@ -154,14 +154,14 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			SetMaterialClip(item.dropZoneMaterial, transform.worldToLocalMatrix);
 
 			m_VisibleItemHeight+= itemSize.z;
-			UpdateItem(item.transform, offset + m_ScrollOffset, ref doneSettling);
+			UpdateItem(item.transform, order, offset + m_ScrollOffset, ref doneSettling);
 
 			var extraSpace = item.extraSpace * itemSize.z;
 			offset += extraSpace;
 			m_VisibleItemHeight += extraSpace;
 		}
 
-		protected override void UpdateRecursively(List<HierarchyData> data, ref float offset, ref bool doneSettling, int depth = 0)
+		protected override void UpdateRecursively(List<HierarchyData> data, ref int order, ref float offset, ref bool doneSettling, int depth = 0)
 		{
 			for (int i = 0; i < data.Count; i++)
 			{
@@ -211,27 +211,27 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 						if (shouldRecycle)
 							Recycle(index);
 						else
-							UpdateHierarchyItem(datum, ref offset, 0, null, ref doneSettling);
+							UpdateHierarchyItem(datum, order++, ref offset, 0, null, ref doneSettling);
 
 						offset += itemSize.z;
 					}
 
 					if (hasChildren)
-						UpdateRecursively(datum.children, ref offset, ref doneSettling);
+						UpdateRecursively(datum.children, ref order, ref offset, ref doneSettling);
 				}
 				else
 				{
 					if (shouldRecycle)
 						Recycle(index);
 					else
-						UpdateHierarchyItem(datum, ref offset, depth, expanded, ref doneSettling);
+						UpdateHierarchyItem(datum, order++, ref offset, depth, expanded, ref doneSettling);
 
 					offset += itemSize.z;
 
 					if (hasChildren)
 					{
 						if (expanded)
-							UpdateRecursively(datum.children, ref offset, ref doneSettling, depth + 1);
+							UpdateRecursively(datum.children, ref order, ref offset, ref doneSettling, depth + 1);
 						else
 							RecycleChildren(datum);
 					}

--- a/Workspaces/InspectorWorkspace/Scripts/InspectorListViewController.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/InspectorListViewController.cs
@@ -116,7 +116,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			}
 		}
 
-		protected override void UpdateRecursively(List<InspectorData> data, ref float offset, ref bool doneSettling, int depth = 0)
+		protected override void UpdateRecursively(List<InspectorData> data, ref int order, ref float offset, ref bool doneSettling, int depth = 0)
 		{
 			for (int i = 0; i < data.Count; i++)
 			{
@@ -140,41 +140,42 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				if (offset + scrollOffset + itemSize.z < 0 || offset + scrollOffset > m_Size.z)
 					Recycle(index);
 				else
-					UpdateItemRecursive(datum, offset, depth, expanded, ref doneSettling);
+					UpdateItemRecursive(datum, order++, offset, depth, expanded, ref doneSettling);
 
 				offset += itemSize.z;
 
 				if (datum.children != null)
 				{
 					if (expanded)
-						UpdateRecursively(datum.children, ref offset, ref doneSettling, depth + 1);
+						UpdateRecursively(datum.children, ref order, ref offset, ref doneSettling, depth + 1);
 					else
 						RecycleChildren(datum);
 				}
 			}
 		}
 
-		void UpdateItemRecursive(InspectorData data, float offset, int depth, bool expanded, ref bool doneSettling)
+		void UpdateItemRecursive(InspectorData data, int order, float offset, int depth, bool expanded, ref bool doneSettling)
 		{
 			InspectorListItem item;
 			if (!m_ListItems.TryGetValue(data.index, out item))
 			{
 				item = GetItem(data);
-				UpdateItem(item.transform, offset, true, ref doneSettling);
+				UpdateItem(item.transform, order, offset, true, ref doneSettling);
 			}
 
 			item.UpdateSelf(m_Size.x - k_ClipMargin, depth, expanded);
 			item.UpdateClipTexts(transform.worldToLocalMatrix, m_Extents);
 
-			UpdateItem(item.transform, offset, false, ref doneSettling);
+			UpdateItem(item.transform, order, offset, false, ref doneSettling);
 		}
 
-		void UpdateItem(Transform t, float offset, bool dontSettle, ref bool doneSettling)
+		void UpdateItem(Transform t, int order, float offset, bool dontSettle, ref bool doneSettling)
 		{
 			var targetPosition = m_StartPosition + (offset + m_ScrollOffset) * Vector3.forward;
 			var targetRotation = Quaternion.identity;
 
-			UpdateItemTransform(t, targetPosition, targetRotation, dontSettle, ref doneSettling);
+			// order is reversed because Inspector draws bottom-to-top, hence the "0" below
+			UpdateItemTransform(t, 0, targetPosition, targetRotation, dontSettle, ref doneSettling);
 		}
 
 		protected override InspectorListItem GetItem(InspectorData listData)

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
@@ -105,6 +105,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		protected override void UpdateItems()
 		{
 			var count = 0;
+			var order = 0;
 			foreach (var data in m_Data)
 			{
 				if (m_NumPerRow == 0) // If the list is too narrow, display nothing
@@ -125,7 +126,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				else
 				{
 					var ignored = true;
-					UpdateVisibleItem(data, count, ref ignored);
+					UpdateVisibleItem(data, order++, count, ref ignored);
 				}
 
 				count++;
@@ -150,14 +151,14 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			});
 		}
 
-		protected override void UpdateVisibleItem(AssetData data, float offset, ref bool doneSettling)
+		protected override void UpdateVisibleItem(AssetData data, int order, float offset, ref bool doneSettling)
 		{
 			AssetGridItem item;
 			if (!m_ListItems.TryGetValue(data.index, out item))
 				item = GetItem(data);
 
 			if (item)
-				UpdateGridItem(item, (int)offset);
+				UpdateGridItem(item, order, (int)offset);
 		}
 
 		public override void OnScrollEnded()
@@ -176,7 +177,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			}
 		}
 
-		void UpdateGridItem(AssetGridItem item, int count)
+		void UpdateGridItem(AssetGridItem item, int order, int count)
 		{
 			item.UpdateTransforms(m_ScaleFactor);
 
@@ -187,6 +188,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			t.localPosition = Vector3.Lerp(t.localPosition, m_StartPosition + zOffset * Vector3.back + xOffset * Vector3.right, k_PositionFollow);
 			t.localRotation = Quaternion.identity;
+
+			t.SetSiblingIndex(order);
 		}
 
 		protected override AssetGridItem GetItem(AssetData data)

--- a/Workspaces/ProjectWorkspace/Scripts/FolderListViewController.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/FolderListViewController.cs
@@ -78,7 +78,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			base.UpdateItems();
 		}
 
-		void UpdateFolderItem(FolderData data, float offset, int depth, bool expanded, ref bool doneSettling)
+		void UpdateFolderItem(FolderData data, int order, float offset, int depth, bool expanded, ref bool doneSettling)
 		{
 			var index = data.index;
 			FolderListItem item;
@@ -89,10 +89,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			SetMaterialClip(item.cubeMaterial, transform.worldToLocalMatrix);
 
-			UpdateItem(item.transform, offset, ref doneSettling);
+			UpdateItem(item.transform, order, offset, ref doneSettling);
 		}
 
-		protected override void UpdateRecursively(List<FolderData> data, ref float offset, ref bool doneSettling, int depth = 0)
+		protected override void UpdateRecursively(List<FolderData> data, ref int order, ref float offset, ref bool doneSettling, int depth = 0)
 		{
 			for (int i = 0; i < data.Count; i++)
 			{
@@ -105,14 +105,14 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				if (offset + scrollOffset + itemSize.z < 0 || offset + scrollOffset > m_Size.z)
 					Recycle(index);
 				else
-					UpdateFolderItem(datum, offset + m_ScrollOffset, depth, expanded, ref doneSettling);
+					UpdateFolderItem(datum, order++, offset + m_ScrollOffset, depth, expanded, ref doneSettling);
 
 				offset += itemSize.z;
 
 				if (datum.children != null)
 				{
 					if (expanded)
-						UpdateRecursively(datum.children, ref offset, ref doneSettling, depth + 1);
+						UpdateRecursively(datum.children, ref order, ref offset, ref doneSettling, depth + 1);
 					else
 						RecycleChildren(datum);
 				}


### PR DESCRIPTION
Fixes #188 

The ultimate solution is just to ensure the proper hierarchy order for ListViewItems. This way we can make sure that UI from one item which overlaps another, lower, item still takes priority.

In the case of the Inspector, because we draw bottom-up, we want the items in reverse order.