### PR TITLE
Haptics bugfixes

### DIFF
--- a/Menus/MainMenu/MainMenu.cs
+++ b/Menus/MainMenu/MainMenu.cs
@@ -88,7 +88,6 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 		public Transform targetRayOrigin { private get; set; }
 		public Type proxyType { private get; set; }
 		public Node? node { get; set; }
-		public Func<Transform, Node?> requestNodeFromRayOrigin { get; set; }
 
 		public GameObject menuContent { get { return m_MainMenuUI.gameObject; } }
 
@@ -226,12 +225,12 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
 		void OnButtonClicked(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_ButtonClickPulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_ButtonClickPulse);
 		}
 
 		void OnButtonHovered(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_ButtonHoverPulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_ButtonHoverPulse);
 		}
 
 		void OnOpening()

--- a/Scripts/Core/EditorVR.Rays.cs
+++ b/Scripts/Core/EditorVR.Rays.cs
@@ -45,6 +45,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 				IGetFieldGrabOriginMethods.getFieldGrabOriginForRayOrigin = GetFieldGrabOriginForRayOrigin;
 				IGetPreviewOriginMethods.getPreviewOriginForRayOrigin = GetPreviewOriginForRayOrigin;
 				IUsesRaycastResultsMethods.getFirstGameObject = GetFirstGameObject;
+				IRayToNodeMethods.requestNodeFromRayOrigin = RequestNodeFromRayOrigin;
 			}
 
 			internal override void OnDestroy()
@@ -87,10 +88,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
 						}
 					}
 				}
-
-				var rayToNode = obj as IRayToNode;
-				if (rayToNode != null)
-					rayToNode.requestNodeFromRayOrigin = RequestNodeFromRayOrigin;
 
 				var selectionModule = obj as SelectionModule;
 				if (selectionModule)

--- a/Scripts/Core/Interfaces/IRayToNode.cs
+++ b/Scripts/Core/Interfaces/IRayToNode.cs
@@ -9,10 +9,20 @@ namespace UnityEditor.Experimental.EditorVR.Core
 	/// </summary>
 	interface IRayToNode
 	{
+	}
+
+	static class IRayToNodeMethods
+	{
+		internal static Func<Transform, Node?> requestNodeFromRayOrigin { private get; set; }
+
 		/// <summary>
 		/// Get the corresponding node for a given ray origin
 		/// </summary>
-		Func<Transform, Node?> requestNodeFromRayOrigin { set; }
+		/// <param name="rayOrigin">The ray origin to request a node for</param>
+		internal static Node? RequestNodeFromRayOrigin(this IRayToNode obj, Transform rayOrigin)
+		{
+			return requestNodeFromRayOrigin(rayOrigin);
+		}
 	}
 }
 #endif

--- a/Scripts/Interfaces/FunctionalityInjection/IControlHaptics.cs
+++ b/Scripts/Interfaces/FunctionalityInjection/IControlHaptics.cs
@@ -1,6 +1,5 @@
 ﻿#if UNITY_EDITOR
 using UnityEditor.Experimental.EditorVR.Core;
-using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR
 {

--- a/Scripts/ListView/HapticPulses/ScrollPulse.asset
+++ b/Scripts/ListView/HapticPulses/ScrollPulse.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1efd705dfe960584581b3390e04777f1, type: 3}
-  m_Name: NewHapticPulse
+  m_Name: ScrollPulse
   m_EditorClassIdentifier: 
   m_Duration: 0.25
   m_Intensity: 1

--- a/Scripts/ListView/ListViewControllerBase.cs
+++ b/Scripts/ListView/ListViewControllerBase.cs
@@ -87,11 +87,7 @@ namespace ListView
 			UpdateView();
 
 			if (m_Scrolling)
-			{
-				if (!m_ScrollPulse)
-				Debug.Log(this, this);
 				this.Pulse(null, m_ScrollPulse);
-			}
 		}
 
 		protected abstract void Setup();

--- a/Scripts/ListView/ListViewControllerBase.cs
+++ b/Scripts/ListView/ListViewControllerBase.cs
@@ -87,7 +87,11 @@ namespace ListView
 			UpdateView();
 
 			if (m_Scrolling)
+			{
+				if (!m_ScrollPulse)
+				Debug.Log(this, this);
 				this.Pulse(null, m_ScrollPulse);
+			}
 		}
 
 		protected abstract void Setup();

--- a/Scripts/Modules/SelectionModule/SelectionModule.cs
+++ b/Scripts/Modules/SelectionModule/SelectionModule.cs
@@ -17,7 +17,6 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
 		public Func<GameObject, GameObject> getGroupRoot { private get; set; }
 		public Func<GameObject, bool> overrideSelectObject { private get; set; }
-		public Func<Transform, Node?> requestNodeFromRayOrigin { get; set; }
 
 		public event Action<Transform> selected;
 
@@ -70,7 +69,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			m_SelectedObjects.Clear();
 
 			if (hoveredObject)
-				this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_HoverPulse);
+				this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_HoverPulse);
 
 			// Multi-Select
 			if (multiSelect)

--- a/Tools/TransformTool/TransformTool.cs
+++ b/Tools/TransformTool/TransformTool.cs
@@ -216,8 +216,6 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
 		public List<ILinkedObject> linkedObjects { private get; set; }
 
-		public Func<Transform, Node?> requestNodeFromRayOrigin { get; set; }
-
 		void Start()
 		{
 			if (!this.IsSharedUpdater(this))
@@ -565,14 +563,14 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 					break;
 			}
 
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_DragPulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_DragPulse);
 		}
 
 		void Rotate(Quaternion delta, Transform rayOrigin)
 		{
 			m_TargetRotation = delta * m_TargetRotation;
 
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_RotatePulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_RotatePulse);
 		}
 
 		void Scale(Vector3 delta)

--- a/Workspaces/Base/HapticPulses/WorkspaceButtonHover.asset
+++ b/Workspaces/Base/HapticPulses/WorkspaceButtonHover.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1efd705dfe960584581b3390e04777f1, type: 3}
-  m_Name: WorkspaceButtonHighlight
+  m_Name: WorkspaceButtonHover
   m_EditorClassIdentifier: 
   m_Duration: 0.005
   m_Intensity: 0.175

--- a/Workspaces/Base/Workspace.cs
+++ b/Workspaces/Base/Workspace.cs
@@ -124,7 +124,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		public Transform leftRayOrigin { protected get; set; }
 		public Transform rightRayOrigin { protected get; set; }
-		public Func<Transform, Node?> requestNodeFromRayOrigin { get; set; }
 
 		public virtual void Setup()
 		{
@@ -164,13 +163,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		protected virtual void OnCloseClicked(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_ButtonClickPulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_ButtonClickPulse);
 			Close();
 		}
 
 		protected virtual void OnResetClicked(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_ButtonClickPulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_ButtonClickPulse);
 
 			this.StopCoroutine(ref m_ResetSizeCoroutine);
 			m_ResetSizeCoroutine = StartCoroutine(AnimateResetSize());
@@ -178,7 +177,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		protected void OnButtonHovered(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_ButtonHoverPulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_ButtonHoverPulse);
 		}
 
 		public void SetUIHighlightsVisible(bool value)
@@ -272,22 +271,22 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		protected void OnButtonClicked(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_ButtonClickPulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_ButtonClickPulse);
 		}
 
 		void OnMoving(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_MovePulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_MovePulse);
 		}
 
 		void OnResizing(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_ResizePulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_ResizePulse);
 		}
 
 		void OnHoveringFrame(Transform rayOrigin)
 		{
-			this.Pulse(requestNodeFromRayOrigin(rayOrigin), m_ResizePulse);
+			this.Pulse(this.RequestNodeFromRayOrigin(rayOrigin), m_ResizePulse);
 		}
 	}
 }

--- a/Workspaces/Common/Scripts/WorkspaceButton.cs
+++ b/Workspaces/Common/Scripts/WorkspaceButton.cs
@@ -204,12 +204,14 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			m_OriginalIconSprite = m_Icon.sprite;
 
-			// Hookup button OnClick event if there is an alternate icon sprite set
-			if (m_SwapIconsOnClick && m_AlternateIconSprite)
-				m_Button.onClick.AddListener(SwapIconSprite);
-
 			if (m_Button)
+			{
+				// Hookup button OnClick event if there is an alternate icon sprite set
+				if (m_SwapIconsOnClick && m_AlternateIconSprite)
+					m_Button.onClick.AddListener(SwapIconSprite);
+
 				m_Button.onClick.AddListener(OnButtonClicked);
+			}
 		}
 
 		void Start()

--- a/Workspaces/Common/Scripts/WorkspaceButton.cs
+++ b/Workspaces/Common/Scripts/WorkspaceButton.cs
@@ -211,7 +211,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			if (m_SwapIconsOnClick && m_AlternateIconSprite)
 				m_Button.onClick.AddListener(SwapIconSprite);
 
-			m_Button.onClick.AddListener(OnButtonClicked);
+			if (m_Button)
+				m_Button.onClick.AddListener(OnButtonClicked);
 		}
 
 		void Start()
@@ -235,7 +236,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			ObjectUtils.Destroy(m_ButtonMaterial);
 			ObjectUtils.Destroy(m_ButtonMaskMaterial);
 
-			m_Button.onClick.RemoveAllListeners();
+			if (m_Button)
+				m_Button.onClick.RemoveAllListeners();
 		}
 
 		void OnDisable()

--- a/Workspaces/Common/Scripts/WorkspaceButton.cs
+++ b/Workspaces/Common/Scripts/WorkspaceButton.cs
@@ -1,7 +1,6 @@
 ﻿#if UNITY_EDITOR
 using System;
 using System.Collections;
-using UnityEditor.Experimental.EditorVR.Core;
 using UnityEditor.Experimental.EditorVR.Extensions;
 using UnityEditor.Experimental.EditorVR.Helpers;
 using UnityEditor.Experimental.EditorVR.Modules;
@@ -165,8 +164,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		public Button button { get { return m_Button; } }
 
 		public byte stencilRef { get; set; }
-
-		public Func<Transform, Node?> requestNodeFromRayOrigin { get; set; }
 
 		public void InstantClearState()
 		{

--- a/Workspaces/ProjectWorkspace/Project.prefab
+++ b/Workspaces/ProjectWorkspace/Project.prefab
@@ -383,6 +383,7 @@ MonoBehaviour:
   m_MaxMomentum: 2
   m_Templates:
   - {fileID: 1000014066556564, guid: 918c55469b1324d46b0c41586835ce87, type: 2}
+  m_ScrollPulse: {fileID: 11400000, guid: 77319cd620700db49a9223c7305480f9, type: 2}
   m_SettleSpeed: 0.3
   m_ScrollSpeed: 0.3
   m_TextMaterial: {fileID: 2100000, guid: 2569ce4f009c407448c0df4aa8d7db55, type: 2}
@@ -402,6 +403,7 @@ MonoBehaviour:
   m_SelectionFlags: 3
   m_HandleTip: {fileID: 0}
   m_OrientDragPlaneToRay: 0
+  m_Constraints: 0
 --- !u!114 &114000011829900818
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -436,6 +438,7 @@ MonoBehaviour:
   m_MaxMomentum: 2
   m_Templates:
   - {fileID: 1000014066556564, guid: 94a0fcdece43c184c88738ce9401f3d0, type: 2}
+  m_ScrollPulse: {fileID: 11400000, guid: 77319cd620700db49a9223c7305480f9, type: 2}
   m_SettleSpeed: 0.3
   m_ScrollSpeed: 0.3
   m_ScaleFactor: 0.056
@@ -471,6 +474,7 @@ MonoBehaviour:
   m_SelectionFlags: 3
   m_HandleTip: {fileID: 0}
   m_OrientDragPlaneToRay: 0
+  m_Constraints: 0
 --- !u!114 &114000013337603310
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
A couple things snuck through in the last PR.
- Workspaces with zoom sliders didn't load correctly because of a null ref in WorkspaceButton
- IRayToNode was using old-style functionality injection
- Project workspace lists were missing their haptic pulse object