### PR TITLE
Fix Clone/Cut/Copy/Paste so that new objects maintain prefab links

### DIFF
--- a/Actions/Clone.cs
+++ b/Actions/Clone.cs
@@ -1,5 +1,4 @@
 ﻿#if UNITY_EDITOR
-using System;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
 
@@ -10,13 +9,12 @@ namespace UnityEditor.Experimental.EditorVR.Actions
 	{
 		public override void ExecuteAction()
 		{
+			Unsupported.DuplicateGameObjectsUsingPasteboard();
 			var selection = Selection.transforms;
-			var clones = new GameObject[selection.Length];
-			var index = 0;
 			var bounds = ObjectUtils.GetBounds(selection);
 			foreach (var s in selection)
 			{
-				var clone = ObjectUtils.Instantiate(s.gameObject);
+				var clone = s.gameObject;
 				clone.hideFlags = HideFlags.None;
 				var cloneTransform = clone.transform;
 				var cameraTransform = CameraUtils.GetMainCamera().transform;
@@ -24,9 +22,7 @@ namespace UnityEditor.Experimental.EditorVR.Actions
 				cloneTransform.position = cameraTransform.TransformPoint(Vector3.forward * viewDirection.magnitude / this.GetViewerScale())
 					+ cloneTransform.position - bounds.center;
 				this.AddToSpatialHash(clone);
-				clones[index++] = clone;
 			}
-			Selection.objects = clones;
 		}
 	}
 }

--- a/Actions/Copy.cs
+++ b/Actions/Copy.cs
@@ -6,7 +6,8 @@ namespace UnityEditor.Experimental.EditorVR.Actions
 	{
 		public override void ExecuteAction()
 		{
-			Paste.buffer = Selection.transforms;
+			Unsupported.CopyGameObjectsToPasteboard();
+			Paste.SetBufferDistance(Selection.transforms);
 		}
 	}
 }

--- a/Actions/Cut.cs
+++ b/Actions/Cut.cs
@@ -11,6 +11,9 @@ namespace UnityEditor.Experimental.EditorVR.Actions
 			var selection = Selection.transforms;
 			if (selection != null)
 			{
+				Unsupported.CopyGameObjectsToPasteboard();
+				Paste.SetBufferDistance(Selection.transforms);
+
 				foreach (var transform in selection)
 				{
 					var go = transform.gameObject;
@@ -18,7 +21,6 @@ namespace UnityEditor.Experimental.EditorVR.Actions
 					go.SetActive(false);
 				}
 
-				Paste.buffer = selection;
 				Selection.activeGameObject = null;
 			}
 		}

--- a/Actions/Paste.cs
+++ b/Actions/Paste.cs
@@ -1,5 +1,4 @@
 ﻿#if UNITY_EDITOR
-using System;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
 
@@ -8,52 +7,34 @@ namespace UnityEditor.Experimental.EditorVR.Actions
 	[ActionMenuItem("Paste", ActionMenuItemAttribute.DefaultActionSectionName, 6)]
 	sealed class Paste : BaseAction, IUsesSpatialHash, IUsesViewerScale
 	{
-		public static Transform[] buffer
-		{
-			get
-			{
-				return s_Buffer;
-			}
-			set
-			{
-				s_Buffer = value;
+		static float s_BufferDistance;
 
-				if (value != null)
-				{
-					var bounds = ObjectUtils.GetBounds(value);
-					
-					s_BufferDistance = bounds.size != Vector3.zero ?
-						(bounds.center - CameraUtils.GetMainCamera().transform.position).magnitude : 1f;
-					s_BufferDistance /= IUsesViewerScaleMethods.getViewerScale(); // Normalize this value, so if viewer scale changes when pasted
-				}
+		public static void SetBufferDistance(Transform[] transforms)
+		{
+			if (transforms != null)
+			{
+				var bounds = ObjectUtils.GetBounds(transforms);
+
+				s_BufferDistance = bounds.size != Vector3.zero ? (bounds.center - CameraUtils.GetMainCamera().transform.position).magnitude : 1f;
+				s_BufferDistance /= IUsesViewerScaleMethods.getViewerScale(); // Normalize this value in case viewer scale changes before paste happens
 			}
 		}
-		static Transform[] s_Buffer;
-
-		static float s_BufferDistance;
 
 		public override void ExecuteAction()
 		{
-			if (buffer != null)
+			Unsupported.PasteGameObjectsFromPasteboard();
+			var transforms = Selection.transforms;
+			var bounds = ObjectUtils.GetBounds(transforms);
+			foreach (var transform in transforms)
 			{
-				var pastedGameObjects = new GameObject[buffer.Length];
-				var index = 0;
-				var bounds = ObjectUtils.GetBounds(buffer);
-				foreach (var transform in buffer)
-				{
-					var pasted = ObjectUtils.Instantiate(transform.gameObject);
-					var pastedTransform = pasted.transform;
-					pasted.hideFlags = HideFlags.None;
-					var cameraTransform = CameraUtils.GetMainCamera().transform;
-					pastedTransform.position = cameraTransform.TransformPoint(Vector3.forward * s_BufferDistance)
-						+ pastedTransform.position - bounds.center;
-					pasted.SetActive(true);
-					this.AddToSpatialHash(pasted);
-					pastedGameObjects[index++] = pasted;
-				}
-
-				if (pastedGameObjects.Length > 0)
-					Selection.objects = pastedGameObjects;
+				var pasted = transform.gameObject;
+				var pastedTransform = pasted.transform;
+				pasted.hideFlags = HideFlags.None;
+				var cameraTransform = CameraUtils.GetMainCamera().transform;
+				pastedTransform.position = cameraTransform.TransformPoint(Vector3.forward * s_BufferDistance)
+					+ pastedTransform.position - bounds.center;
+				pasted.SetActive(true);
+				this.AddToSpatialHash(pasted);
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose of this PR
The current Clone/Cut/Copy/Paste actions create new objects which are not properly lined to prefabs like the originals.

### Testing status
Tested on a few sample prefabs, including the ArcheryWeeble from our SIGGRAPH talk (basically the same as the one in SteamVR). Easy way to know it's not working is if you accidentally "pick apart" a cloned object whose root transform does not have a renderer.

### Technical risk
Low; Only affects these 4 actions and uses an identical method to normal editor actions.

### Comments to reviewers
I'm not thrilled about using stuff in Unsupported, but this was the only way I could find to properly duplicate prefabs. This is what happens when you press ctrl-D, ctrl-C, ctrl-V, and ctrl-X. I tried using PrefabUtility to do the instantiate, or hook up the new object to the old prefab. If you instantiate the prefab, you then have to go make all the override changes, and if you try to call connectprefab, you get an error about hideflags.

Fixes #38