### PR TITLE
Fix menu rotation on Vive

### DIFF
--- a/Menus/MainMenu/MainMenu.cs
+++ b/Menus/MainMenu/MainMenu.cs
@@ -135,8 +135,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 			{
 				m_MainMenuUI.targetFaceIndex += (int)Mathf.Sign(rotationInput);
 				this.Pulse(node, m_FaceRotationPulse);
-				consumeControl(mainMenuInput.flickFace);
 			}
+
+			if (visible)
+				consumeControl(mainMenuInput.flickFace);
 
 			m_LastRotationInput = rotationInput;
 		}


### PR DESCRIPTION
### Purpose of this PR
The Locomotion branch introduced changes that consume the thumbpad press action, which was blocking the "flickFace" action in the menu, which is required to rotate menu faces on Vive.

### Testing status
Tested on Vive and Rift using OpenVR

### Technical risk
Medium: Other systems might be using the thumbpad, but I am still able to locomote and use the radial menu.  Because the menus are processed before tools, this will also override any user tools that might need thumbpad press while the menu is visible. Although, having the menu up on the same hand as a tool is already problematic.

### Comments to reviewers
Though there is some risk whenever we mess around with consuming controls, we need this fix because otherwise you can't rotate the menu at all when using OpenVR