### PR TITLE
Asset Grid Preview All

### DIFF
--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using UnityEditor.Experimental.EditorVR.Extensions;
 using UnityEditor.Experimental.EditorVR.Menus;
 using UnityEditor.Experimental.EditorVR.Modules;
 using UnityEditor.Experimental.EditorVR.Utilities;
@@ -188,7 +189,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 					obj.transform.parent = null;
 					obj.position = referenceTransform.position + Vector3.Scale(miniWorld.miniWorldTransform.InverseTransformPoint(obj.position), miniWorld.referenceTransform.localScale);
 					obj.rotation = referenceTransform.rotation * Quaternion.Inverse(miniWorld.miniWorldTransform.rotation) * obj.rotation;
-					obj.localScale = Vector3.Scale(Vector3.Scale(obj.localScale, referenceTransform.localScale), miniWorld.miniWorldTransform.lossyScale);
+					obj.localScale = Vector3.Scale(Vector3.Scale(obj.localScale, referenceTransform.localScale), miniWorld.miniWorldTransform.lossyScale.Inverse());
 
 					spatialHashModule.AddObject(obj.gameObject);
 					return true;

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridItem.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridItem.cs
@@ -77,26 +77,23 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				m_Cube.gameObject.SetActive(false);
 				m_Sphere.gameObject.SetActive(false);
 
-				if (m_IconPrefab == value)
+				if (m_IconPrefab == value) // If this GridItem already has this icon loaded, jus trefresh it's active state
 				{
-					m_Icon.SetActive(true);
-					if (m_PreviewObjectTransform && !m_AutoHidePreview)
-						m_Icon.SetActive(false);
-
+					m_Icon.SetActive(!m_PreviewObjectTransform || m_AutoHidePreview);
 					return;
 				}
 
 				if (m_Icon)
 					ObjectUtils.Destroy(m_Icon);
 
+				if (m_PreviewObjectTransform && !m_AutoHidePreview) // We don't need the icon if we never hide the preview
+					return;
+
 				m_IconPrefab = value;
 				m_Icon = ObjectUtils.Instantiate(m_IconPrefab, transform, false);
 				m_Icon.transform.localPosition = Vector3.up * 0.5f;
 				m_Icon.transform.localRotation = Quaternion.AngleAxis(90, Vector3.down);
 				m_Icon.transform.localScale = Vector3.one;
-
-				if (m_PreviewObjectTransform && !m_AutoHidePreview)
-					m_Icon.SetActive(false);
 			}
 		}
 
@@ -530,7 +527,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 				if (maxComponent < k_MinPreviewScale)
 				{
-					// Object will be preview at the maximum scale
+					// Object will be preview at the minimum scale
 					targetScale = Vector3.one * k_MinPreviewScale;
 					pivotOffset = pivotOffset * scaleFactor + (Vector3.up + Vector3.forward) * 0.5f * k_MinPreviewScale;
 				}

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridItem.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridItem.cs
@@ -77,7 +77,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				m_Cube.gameObject.SetActive(false);
 				m_Sphere.gameObject.SetActive(false);
 
-				if (m_IconPrefab == value) // If this GridItem already has this icon loaded, jus trefresh it's active state
+				if (m_IconPrefab == value) // If this GridItem already has this icon loaded, just refresh it's active state
 				{
 					m_Icon.SetActive(!m_PreviewObjectTransform || m_AutoHidePreview);
 					return;
@@ -86,14 +86,14 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				if (m_Icon)
 					ObjectUtils.Destroy(m_Icon);
 
-				if (m_PreviewObjectTransform && !m_AutoHidePreview) // We don't need the icon if we never hide the preview
-					return;
-
 				m_IconPrefab = value;
 				m_Icon = ObjectUtils.Instantiate(m_IconPrefab, transform, false);
 				m_Icon.transform.localPosition = Vector3.up * 0.5f;
 				m_Icon.transform.localRotation = Quaternion.AngleAxis(90, Vector3.down);
 				m_Icon.transform.localScale = Vector3.one;
+
+				if (m_PreviewObjectTransform && !m_AutoHidePreview)
+					m_Icon.SetActive(false);
 			}
 		}
 

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridItem.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridItem.cs
@@ -11,13 +11,19 @@ using UnityEngine.UI;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
-	sealed class AssetGridItem : DraggableListItem<AssetData, string>, IPlaceSceneObject, IUsesSpatialHash, IUsesViewerBody
+	sealed class AssetGridItem : DraggableListItem<AssetData, string>, IPlaceSceneObject, IUsesSpatialHash, 
+		IUsesViewerBody, ISetDefaultRayVisibility
 	{
 		const float k_PreviewDuration = 0.1f;
+		const float k_MinPreviewScale = 0.01f;
 		const float k_MaxPreviewScale = 0.2f;
 		const float k_RotateSpeed = 50f;
 		const float k_TransitionDuration = 0.1f;
+		const float k_ScaleBump = 1.1f;
 		const int k_PreviewRenderQueue = 9200;
+
+		const int k_AutoHidePreviewVertexCount = 10000;
+		const int k_HidePreviewVertexCount = 100000;
 
 		[SerializeField]
 		Text m_Text;
@@ -45,10 +51,11 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		Transform m_PreviewObjectTransform;
 
 		bool m_Setup;
+		bool m_AutoHidePreview;
 		Vector3 m_PreviewPrefabScale;
 		Vector3 m_PreviewTargetScale;
-		Vector3 m_GrabPreviewTargetScale;
-		Vector3 m_GrabPreviewPivotOffset;
+		Vector3 m_PreviewPivotOffset;
+		Bounds m_PreviewBounds;
 		Transform m_PreviewObjectClone;
 
 		Coroutine m_PreviewCoroutine;
@@ -72,6 +79,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				if (m_IconPrefab == value)
 				{
 					m_Icon.SetActive(true);
+					if (m_PreviewObjectTransform && !m_AutoHidePreview)
+						m_Icon.SetActive(false);
+
 					return;
 				}
 
@@ -83,6 +93,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				m_Icon.transform.localPosition = Vector3.up * 0.5f;
 				m_Icon.transform.localRotation = Quaternion.AngleAxis(90, Vector3.down);
 				m_Icon.transform.localScale = Vector3.one;
+
+				if (m_PreviewObjectTransform && !m_AutoHidePreview)
+					m_Icon.SetActive(false);
 			}
 		}
 
@@ -154,6 +167,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			m_PreviewCoroutine = null;
 			m_VisibilityCoroutine = null;
+			m_AutoHidePreview = false;
+			icon.transform.localScale = Vector3.one;
 
 			// First time setup
 			if (!m_Setup)
@@ -174,11 +189,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			}
 
 			InstantiatePreview();
-
-			icon.transform.localScale = Vector3.one;
-
-			if (m_PreviewObjectTransform)
-				m_PreviewObjectTransform.localScale = Vector3.zero;
 
 			m_Text.text = listData.name;
 		}
@@ -221,10 +231,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			m_PreviewPrefabScale = m_PreviewObjectTransform.localScale;
 
 			// Normalize total scale to 1
-			var previewTotalBounds = ObjectUtils.GetBounds(m_PreviewObjectTransform);
+			m_PreviewBounds = ObjectUtils.GetBounds(m_PreviewObjectTransform);
 
 			// Don't show a preview if there are no renderers
-			if (previewTotalBounds.size == Vector3.zero)
+			if (m_PreviewBounds.size == Vector3.zero)
 			{
 				ObjectUtils.Destroy(m_PreviewObjectTransform.gameObject);
 				return;
@@ -245,42 +255,55 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				light.enabled = false;
 			}
 
-			var pivotOffset = m_PreviewObjectTransform.position - previewTotalBounds.center;
+			m_PreviewPivotOffset = m_PreviewObjectTransform.position - m_PreviewBounds.center;
 			m_PreviewObjectTransform.SetParent(transform, false);
 
-			var maxComponent = previewTotalBounds.size.MaxComponent();
+			var maxComponent = m_PreviewBounds.size.MaxComponent();
 			var scaleFactor = 1 / maxComponent;
 			m_PreviewTargetScale = m_PreviewPrefabScale * scaleFactor;
-			m_PreviewObjectTransform.localPosition = pivotOffset * scaleFactor + Vector3.up * 0.5f;
+			m_PreviewObjectTransform.localPosition = m_PreviewPivotOffset * scaleFactor + Vector3.up * 0.5f;
 
-			// Object will preview at the same size when grabbed
-			m_GrabPreviewTargetScale = Vector3.one * maxComponent;
-			var previewExtents = previewTotalBounds.extents;
-			m_GrabPreviewPivotOffset = pivotOffset;
-
-			// If bounds are greater than offset, set to bounds
-			if (previewExtents.y > m_GrabPreviewPivotOffset.y)
-				m_GrabPreviewPivotOffset.y = previewExtents.y;
-
-			if (previewExtents.z > m_GrabPreviewPivotOffset.z)
-				m_GrabPreviewPivotOffset.z = previewExtents.z;
-
-			if (maxComponent > k_MaxPreviewScale)
+			var vertCount = 0;
+			foreach (var meshFilter in m_PreviewObjectTransform.GetComponentsInChildren<MeshFilter>())
 			{
-				// Object will be preview at the maximum scale
-				m_GrabPreviewTargetScale = Vector3.one * k_MaxPreviewScale;
-				m_GrabPreviewPivotOffset = pivotOffset * scaleFactor + (Vector3.up + Vector3.forward) * 0.5f * k_MaxPreviewScale;
+				if (meshFilter.sharedMesh)
+					vertCount += meshFilter.sharedMesh.vertexCount;
 			}
 
-			m_PreviewObjectTransform.gameObject.SetActive(false);
-			m_PreviewObjectTransform.localScale = Vector3.zero;
+			foreach (var skinnedMeshRenderer in m_PreviewObjectTransform.GetComponentsInChildren<SkinnedMeshRenderer>()) {
+				if (skinnedMeshRenderer.sharedMesh)
+					vertCount += skinnedMeshRenderer.sharedMesh.vertexCount;
+			}
+
+			// Do not show previews over a max vert count
+			if (vertCount > k_HidePreviewVertexCount)
+			{
+				ObjectUtils.Destroy(m_PreviewObjectTransform.gameObject);
+				return;
+			}
+
+			// Auto hide previews over a smaller vert count
+			if (vertCount > k_AutoHidePreviewVertexCount)
+			{
+				m_AutoHidePreview = true;
+				m_PreviewObjectTransform.localScale = Vector3.zero;
+			}
+			else
+			{
+				m_PreviewObjectTransform.localScale = m_PreviewTargetScale;
+				icon.SetActive(false);
+			}
 		}
 
 		protected override void OnDragStarted(BaseHandle handle, HandleEventData eventData)
 		{
 			base.OnDragStarted(handle, eventData);
 
-			var clone = (GameObject)Instantiate(gameObject, transform.position, transform.rotation, transform.parent);
+			var rayOrigin = eventData.rayOrigin;
+			this.SetDefaultRayVisibility(rayOrigin, false);
+			this.LockRay(rayOrigin, this);
+
+			var clone = Instantiate(gameObject, transform.position, transform.rotation, transform.parent);
 			var cloneItem = clone.GetComponent<AssetGridItem>();
 
 			if (cloneItem.m_PreviewObjectTransform)
@@ -327,6 +350,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		{
 			var gridItem = m_DragObject.GetComponent<AssetGridItem>();
 
+			var rayOrigin = eventData.rayOrigin;
+			this.UnlockRay(rayOrigin, this);
+			this.SetDefaultRayVisibility(rayOrigin, true);
+
 			if (!this.IsOverShoulder(eventData.rayOrigin))
 			{
 				if (gridItem.m_PreviewObjectTransform)
@@ -361,8 +388,15 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		{
 			if (m_PreviewObjectTransform && gameObject.activeInHierarchy)
 			{
-				this.StopCoroutine(ref m_PreviewCoroutine);
-				m_PreviewCoroutine = StartCoroutine(AnimatePreview(false));
+				if (m_AutoHidePreview)
+				{
+					this.StopCoroutine(ref m_PreviewCoroutine);
+					m_PreviewCoroutine = StartCoroutine(AnimatePreview(false));
+				}
+				else
+				{
+					m_PreviewObjectTransform.localScale = m_PreviewTargetScale * k_ScaleBump;
+				}
 			}
 		}
 
@@ -370,8 +404,15 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		{
 			if (m_PreviewObjectTransform && gameObject.activeInHierarchy)
 			{
-				this.StopCoroutine(ref m_PreviewCoroutine);
-				m_PreviewCoroutine = StartCoroutine(AnimatePreview(true));
+				if (m_AutoHidePreview)
+				{
+					this.StopCoroutine(ref m_PreviewCoroutine);
+					m_PreviewCoroutine = StartCoroutine(AnimatePreview(true));
+				}
+				else
+				{
+					m_PreviewObjectTransform.localScale = m_PreviewTargetScale;
+				}
 			}
 		}
 
@@ -465,21 +506,48 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			var currentVelocity = 0f;
 			const float kDuration = 1f;
 
+			var viewerScale = this.GetViewerScale();
+			var maxComponent = m_PreviewBounds.size.MaxComponent() / viewerScale;
+			var targetScale = Vector3.one * maxComponent;
+			
+			// Object will preview at the same size when grabbed
+			var previewExtents = m_PreviewBounds.extents / viewerScale;
+			var pivotOffset = m_PreviewPivotOffset / viewerScale;
+
+			// If bounds are greater than offset, set to bounds
+			if (previewExtents.y > pivotOffset.y)
+				pivotOffset.y = previewExtents.y;
+
+			if (previewExtents.z > pivotOffset.z)
+				pivotOffset.z = previewExtents.z;
+
+			if (maxComponent < k_MinPreviewScale) {
+				// Object will be preview at the maximum scale
+				targetScale = Vector3.one * k_MinPreviewScale;
+				pivotOffset = pivotOffset * scaleFactor + (Vector3.up + Vector3.forward) * 0.5f * k_MinPreviewScale;
+			}
+
+			if (maxComponent > k_MaxPreviewScale) {
+				// Object will be preview at the maximum scale
+				targetScale = Vector3.one * k_MaxPreviewScale;
+				pivotOffset = pivotOffset * scaleFactor + (Vector3.up + Vector3.forward) * 0.5f * k_MaxPreviewScale;
+			}
+
 			while (currentTime < kDuration - 0.05f)
 			{
 				if (m_DragObject == null)
 					yield break; // Exit coroutine if m_GrabbedObject is destroyed before the loop is finished
 
 				currentTime = MathUtilsExt.SmoothDamp(currentTime, kDuration, ref currentVelocity, 0.5f, Mathf.Infinity, Time.deltaTime);
-				m_DragObject.localScale = Vector3.Lerp(currentLocalScale, m_GrabPreviewTargetScale, currentTime);
+				m_DragObject.localScale = Vector3.Lerp(currentLocalScale, targetScale, currentTime);
 
 				if (m_PreviewObjectClone)
-					m_PreviewObjectClone.localPosition = Vector3.Lerp(currentPreviewOffset, m_GrabPreviewPivotOffset, currentTime);
+					m_PreviewObjectClone.localPosition = Vector3.Lerp(currentPreviewOffset, pivotOffset, currentTime);
 
 				yield return null;
 			}
 
-			m_DragObject.localScale = m_GrabPreviewTargetScale;
+			m_DragObject.localScale = targetScale;
 		}
 
 		static IEnumerator HideGrabbedObject(GameObject itemToHide, Renderer cubeRenderer)

--- a/Workspaces/ProjectWorkspace/Scripts/FolderListViewController.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/FolderListViewController.cs
@@ -136,6 +136,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		void ToggleExpanded(string index)
 		{
+			if (data.Count == 1 && m_ListItems[index].data == data[0]) // Do not collapse Assets folder
+				return;
+
 			m_ExpandStates[index] = !m_ExpandStates[index];
 			StartSettling();
 		}


### PR DESCRIPTION
### Purpose of this PR
Show a 3D preview for all objects in the Asset Grid below a certain vert count.

### Testing status
Tested with Polygon Adventure pack and miscellaneous models/prefabs/assets I have in my project

### Technical risk
Medium; The vert count might not be quite right, or need adjustment for minspec machines. We were already loading the previews, so this won't require any more memory, and is equally likely to run into errors on load.

### Comments to reviewers
This was something that came up during the planning of our SIGGRAPH demo. It looks really great!