### PR TITLE
Skinned Mesh Support

### DIFF
--- a/Scripts/Helpers/VRSmoothCamera.cs
+++ b/Scripts/Helpers/VRSmoothCamera.cs
@@ -73,7 +73,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 			m_SmoothCamera.targetTexture = m_RenderTexture;
 			m_SmoothCamera.targetDisplay = m_TargetDisplay;
 			m_SmoothCamera.cameraType = CameraType.Game;
-			//m_SmoothCamera.cullingMask &= ~hmdOnlyLayerMask;
+			m_SmoothCamera.cullingMask &= ~hmdOnlyLayerMask;
 			m_SmoothCamera.rect = new Rect(0f, 0f, 1f, 1f);
 			m_SmoothCamera.stereoTargetEye = StereoTargetEyeMask.None;
 			m_SmoothCamera.fieldOfView = m_FieldOfView;

--- a/Scripts/Helpers/VRSmoothCamera.cs
+++ b/Scripts/Helpers/VRSmoothCamera.cs
@@ -73,7 +73,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 			m_SmoothCamera.targetTexture = m_RenderTexture;
 			m_SmoothCamera.targetDisplay = m_TargetDisplay;
 			m_SmoothCamera.cameraType = CameraType.Game;
-			m_SmoothCamera.cullingMask &= ~hmdOnlyLayerMask;
+			//m_SmoothCamera.cullingMask &= ~hmdOnlyLayerMask;
 			m_SmoothCamera.rect = new Rect(0f, 0f, 1f, 1f);
 			m_SmoothCamera.stereoTargetEye = StereoTargetEyeMask.None;
 			m_SmoothCamera.fieldOfView = m_FieldOfView;

--- a/Scripts/Modules/HighlightModule/HighlightModule.cs
+++ b/Scripts/Modules/HighlightModule/HighlightModule.cs
@@ -3,10 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.Rendering;
 
-namespace UnityEditor.Experimental.EditorVR.Modules
-{
+namespace UnityEditor.Experimental.EditorVR.Modules {
 	sealed class HighlightModule : MonoBehaviour, IUsesGameObjectLocking
 	{
 		[SerializeField]
@@ -20,7 +18,8 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
 		readonly Dictionary<Material, HashSet<GameObject>> m_Highlights = new Dictionary<Material, HashSet<GameObject>>();
 		readonly Dictionary<Node, HashSet<Transform>> m_NodeMap = new Dictionary<Node, HashSet<Transform>>();
-		readonly Dictionary<Camera, CommandBuffer> m_CommandBuffers = new Dictionary<Camera, CommandBuffer>();
+
+		static Mesh s_BakedMesh;
 
 		public event Func<GameObject, Material, bool> customHighlight
 		{
@@ -39,31 +38,13 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			get { return m_RightHighlightMaterial.color; }
 		}
 
-		void OnEnable()
+		void Awake()
 		{
-			foreach (var currentCamera in Resources.FindObjectsOfTypeAll<Camera>())
-			{
-				var buffer = new CommandBuffer();
-				currentCamera.AddCommandBuffer(CameraEvent.AfterForwardAlpha, buffer);
-				m_CommandBuffers[currentCamera] = buffer;
-			}
-		}
-
-		void OnDisable()
-		{
-			foreach (var kvp in m_CommandBuffers) {
-				kvp.Key.RemoveCommandBuffer(CameraEvent.AfterForwardOpaque, kvp.Value);
-			}
-			m_CommandBuffers.Clear();
+			s_BakedMesh = new Mesh();
 		}
 
 		void LateUpdate()
 		{
-			foreach (var kvp in m_CommandBuffers)
-			{
-				kvp.Value.Clear();
-			}
-
 			foreach (var highlight in m_Highlights)
 			{
 				var material = highlight.Key;
@@ -87,33 +68,34 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			}
 		}
 
-		void HighlightObject(GameObject go, Material material)
+		static void HighlightObject(GameObject go, Material material)
 		{
-			//foreach (var m in go.GetComponentsInChildren<MeshFilter>())
-			//{
-			//	if (m.sharedMesh == null)
-			//		continue;
-
-			//	for (var i = 0; i < m.sharedMesh.subMeshCount; i++)
-			//		Graphics.DrawMesh(m.sharedMesh, m.transform.localToWorldMatrix, material, m.gameObject.layer, null, i);
-			//}
-
-			foreach (var kvp in m_CommandBuffers)
+			foreach (var meshFilter in go.GetComponentsInChildren<MeshFilter>())
 			{
-				var buffer = kvp.Value;
-				foreach (var m in go.GetComponentsInChildren<Renderer>())
+				var mesh = meshFilter.sharedMesh;
+				if (meshFilter.sharedMesh == null)
+					continue;
+
+				var localToWorldMatrix = meshFilter.transform.localToWorldMatrix;
+				var layer = meshFilter.gameObject.layer;
+				for (var i = 0; i < meshFilter.sharedMesh.subMeshCount; i++)
 				{
-					//if (m.sharedMesh == null)
-					//	continue;
+					Graphics.DrawMesh(mesh, localToWorldMatrix, material, layer, null, i);
+				}
+			}
 
-					//s_CommandBuffer.Clear();
-					//s_CommandBuffer.SetRenderTarget(RenderTexture.active);
-					//Debug.Log(m + ", " + m.gameObject.hideFlags);
-					buffer.DrawRenderer(m, material);
-					Graphics.ExecuteCommandBuffer(buffer);
+			foreach (var skinnedMeshRenderer in go.GetComponentsInChildren<SkinnedMeshRenderer>())
+			{
+				if (skinnedMeshRenderer.sharedMesh == null)
+					continue;
 
-					//for (var i = 0; i < m.sharedMesh.subMeshCount; i++)
-					//	Graphics.DrawMesh(m.sharedMesh, m.transform.localToWorldMatrix, material, m.gameObject.layer, null, i);
+				skinnedMeshRenderer.BakeMesh(s_BakedMesh);
+
+				var localToWorldMatrix = skinnedMeshRenderer.transform.localToWorldMatrix;
+				var layer = skinnedMeshRenderer.gameObject.layer;
+				for (var i = 0; i < s_BakedMesh.subMeshCount; i++)
+				{
+					Graphics.DrawMesh(s_BakedMesh, localToWorldMatrix, material, layer, null, i);
 				}
 			}
 		}

--- a/Scripts/Modules/HighlightModule/HighlightModule.cs
+++ b/Scripts/Modules/HighlightModule/HighlightModule.cs
@@ -72,6 +72,15 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 				for (var i = 0; i < m.sharedMesh.subMeshCount; i++)
 					Graphics.DrawMesh(m.sharedMesh, m.transform.localToWorldMatrix, material, m.gameObject.layer, null, i);
 			}
+
+			foreach (var m in go.GetComponentsInChildren<SkinnedMeshRenderer>())
+			{
+				if (m.sharedMesh == null)
+					continue;
+
+				for (var i = 0; i < m.sharedMesh.subMeshCount; i++)
+					Graphics.DrawMesh(m.sharedMesh, m.transform.localToWorldMatrix, material, m.gameObject.layer, null, i);
+			}
 		}
 
 		public void AddRayOriginForNode(Node node, Transform rayOrigin)

--- a/Scripts/Modules/IntersectionModule/IntersectionModule.cs
+++ b/Scripts/Modules/IntersectionModule/IntersectionModule.cs
@@ -216,6 +216,8 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
 					var transform = renderer.transform;
 
+					IntersectionUtils.SetupCollisionTester(m_CollisionTester, transform);
+
 					RaycastHit tmp;
 					if (IntersectionUtils.TestRay(m_CollisionTester, transform, ray, out tmp, maxDistance))
 					{

--- a/Scripts/Modules/SpatialHashModule.cs
+++ b/Scripts/Modules/SpatialHashModule.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
 		void SetupObjects()
 		{
-			MeshFilter[] meshFilters = FindObjectsOfType<MeshFilter>();
+			var meshFilters = FindObjectsOfType<MeshFilter>();
 			foreach (var mf in meshFilters)
 			{
 				if (mf.sharedMesh)
@@ -40,9 +40,19 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 						spatialHash.AddObject(renderer, renderer.bounds);
 				}
 			}
+
+			var skinnedMeshRenderers = FindObjectsOfType<SkinnedMeshRenderer>();
+			foreach (var skinnedMeshRenderer in skinnedMeshRenderers) {
+				if (skinnedMeshRenderer.sharedMesh) {
+					if (shouldExcludeObject != null && shouldExcludeObject(skinnedMeshRenderer.gameObject))
+						continue;
+
+					spatialHash.AddObject(skinnedMeshRenderer, skinnedMeshRenderer.bounds);
+				}
+			}
 		}
 
-		private IEnumerator UpdateDynamicObjects()
+		IEnumerator UpdateDynamicObjects()
 		{
 			while (true)
 			{

--- a/Scripts/Modules/SpatialHashModule.cs
+++ b/Scripts/Modules/SpatialHashModule.cs
@@ -42,8 +42,10 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			}
 
 			var skinnedMeshRenderers = FindObjectsOfType<SkinnedMeshRenderer>();
-			foreach (var skinnedMeshRenderer in skinnedMeshRenderers) {
-				if (skinnedMeshRenderer.sharedMesh) {
+			foreach (var skinnedMeshRenderer in skinnedMeshRenderers)
+			{
+				if (skinnedMeshRenderer.sharedMesh)
+				{
 					if (shouldExcludeObject != null && shouldExcludeObject(skinnedMeshRenderer.gameObject))
 						continue;
 

--- a/Scripts/Utilities/IntersectionUtils.cs
+++ b/Scripts/Utilities/IntersectionUtils.cs
@@ -7,8 +7,8 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 	static class IntersectionUtils
 	{
 		// Local method use only -- created here to reduce garbage collection
-		static readonly Vector3[] s_TriangleVertices = new Vector3[3];
-		static Mesh s_BakedMesh = new Mesh();
+		static readonly Vector3[] k_TriangleVertices = new Vector3[3];
+		static readonly Mesh k_BakedMesh = new Mesh();
 
 		/// <summary>
 		/// Test whether an object collides with the tester
@@ -58,16 +58,16 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 			var testerTransform = tester.transform;
 			for (var i = 0; i < triangles.Length; i += 3)
 			{
-				s_TriangleVertices[0] = vertices[triangles[i]];
-				s_TriangleVertices[1] = vertices[triangles[i + 1]];
-				s_TriangleVertices[2] = vertices[triangles[i + 2]];
+				k_TriangleVertices[0] = vertices[triangles[i]];
+				k_TriangleVertices[1] = vertices[triangles[i + 1]];
+				k_TriangleVertices[2] = vertices[triangles[i + 2]];
 
 				for (var j = 0; j < 3; j++)
 				{
 					RaycastHit hitInfo;
 
-					var start = obj.InverseTransformPoint(testerTransform.TransformPoint(s_TriangleVertices[j]));
-					var end = obj.InverseTransformPoint(testerTransform.TransformPoint(s_TriangleVertices[(j + 1) % 3]));
+					var start = obj.InverseTransformPoint(testerTransform.TransformPoint(k_TriangleVertices[j]));
+					var end = obj.InverseTransformPoint(testerTransform.TransformPoint(k_TriangleVertices[(j + 1) % 3]));
 					var edge = end - start;
 					var maxDistance = Mathf.Max(edge.magnitude, boundsMagnitude);
 					var direction = edge.normalized;
@@ -192,8 +192,8 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 				var smr = obj.GetComponent<SkinnedMeshRenderer>();
 				if (smr)
 				{
-					smr.BakeMesh(s_BakedMesh);
-					collisionTester.sharedMesh = s_BakedMesh;
+					smr.BakeMesh(k_BakedMesh);
+					collisionTester.sharedMesh = k_BakedMesh;
 				}
 			}
 		}

--- a/Scripts/Utilities/IntersectionUtils.cs
+++ b/Scripts/Utilities/IntersectionUtils.cs
@@ -20,6 +20,8 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 		{
 			var transform = obj.transform;
 
+			SetupCollisionTester(collisionTester, transform);
+
 			// Try a simple test with specific rays located at vertices
 			for (var j = 0; j < tester.rays.Length; j++)
 			{
@@ -47,10 +49,6 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 		/// <returns>The result of whether the point/ray is intersection with or located within the object</returns>
 		public static bool TestEdges(MeshCollider collisionTester, Transform obj, IntersectionTester tester)
 		{
-			var mf = obj.GetComponent<MeshFilter>();
-			if (mf)
-				collisionTester.sharedMesh = mf.sharedMesh;
-
 			var boundsMagnitude = collisionTester.bounds.size.magnitude;
 
 			var triangles = tester.triangles;
@@ -132,10 +130,6 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 		/// <returns>The result of whether the point/ray is intersection with or located within the object</returns>
 		public static bool TestRay(MeshCollider collisionTester, Transform obj, Ray ray)
 		{
-			var mf = obj.GetComponent<MeshFilter>();
-			if (mf)
-				collisionTester.sharedMesh = mf.sharedMesh;
-
 			ray.origin = obj.InverseTransformPoint(ray.origin);
 			ray.direction = obj.InverseTransformDirection(ray.direction);
 		
@@ -179,15 +173,25 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 		/// <returns>The result of whether the ray intersects with the object</returns>
 		public static bool TestRay(MeshCollider collisionTester, Transform obj, Ray ray, out RaycastHit hit, float maxDistance = Mathf.Infinity)
 		{
-			var mf = obj.GetComponent<MeshFilter>();
-			if (mf)
-				collisionTester.sharedMesh = mf.sharedMesh;
-
 			ray.origin = obj.InverseTransformPoint(ray.origin);
 			ray.direction = obj.InverseTransformVector(ray.direction);
 			maxDistance = obj.InverseTransformVector(ray.direction * maxDistance).magnitude;
 
 			return collisionTester.Raycast(ray, out hit, maxDistance);
+		}
+
+		public static void SetupCollisionTester(MeshCollider collisionTester, Transform obj)
+		{
+			var mf = obj.GetComponent<MeshFilter>();
+			if (mf)
+				collisionTester.sharedMesh = mf.sharedMesh;
+
+			if (!mf)
+			{
+				var smr = obj.GetComponent<SkinnedMeshRenderer>();
+				if (smr)
+					collisionTester.sharedMesh = smr.sharedMesh;
+			}
 		}
 	}
 }

--- a/Scripts/Utilities/IntersectionUtils.cs
+++ b/Scripts/Utilities/IntersectionUtils.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 	{
 		// Local method use only -- created here to reduce garbage collection
 		static readonly Vector3[] s_TriangleVertices = new Vector3[3];
+		static Mesh s_BakedMesh = new Mesh();
 
 		/// <summary>
 		/// Test whether an object collides with the tester
@@ -190,7 +191,10 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 			{
 				var smr = obj.GetComponent<SkinnedMeshRenderer>();
 				if (smr)
-					collisionTester.sharedMesh = smr.sharedMesh;
+				{
+					smr.BakeMesh(s_BakedMesh);
+					collisionTester.sharedMesh = s_BakedMesh;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose of this PR
Skinned meshes can't be selected or direct manipulated because they weren't added to the spatial hash.

### Testing status
Tested with various characters from Polygon Adventure pack and bow from SteamVR

### Technical risk
Medium; Might see some errors trying to use certain skinned meshes in MeshColliders.

### Comments to reviewers
I can't exactly remember why we didn't add them originally. I think we saw some errors on certain models, but I don't see anything now. As you might expect, once the character has been posed, you can't hover-and-select all visible parts of the model, and you see an outline of the T-pose on hover. This is an inherent limitation of the MeshCollider component, which can't deform skinned meshes (as far as I know). We could try bringing back the PixelRaycastModule which did regular Scene Picking using a GPU readback, but removing it was a nice boost to performance, so I'd rather not.