### PR TITLE
Hierarchy prefab colors

### DIFF
--- a/Workspaces/HierarchyWorkspace/Prefabs/HierarchyListItem.prefab
+++ b/Workspaces/HierarchyWorkspace/Prefabs/HierarchyListItem.prefab
@@ -407,8 +407,11 @@ MonoBehaviour:
   m_NoClipExpandArrow: {fileID: 2100000, guid: d066c89af6b2b864cb02f409d89ce3ba, type: 2}
   m_NoClipBackingCube: {fileID: 2100000, guid: 1a070009f7968b74abbf1a1ae823b472, type: 2}
   m_NoClipText: {fileID: 2100000, guid: 0b1d2d3c4b2d7d948bcd67e085daa7d4, type: 2}
-  m_HoverColor: {r: 0.20344828, g: 0.20344828, b: 0.20344828, a: 0}
-  m_SelectedColor: {r: 0.36896548, g: 0.36896548, b: 0.36896548, a: 0}
+  m_HoverColor: {r: 0.15686275, g: 0.15686275, b: 0.15686275, a: 0}
+  m_SelectedColor: {r: 0.23529412, g: 0.23529412, b: 0.23529412, a: 0}
+  m_SelectedHoverColor: {r: 0.3137255, g: 0.3137255, b: 0.3137255, a: 0}
+  m_PrefabTextColor: {r: 0.28627452, g: 0.45490196, b: 0.7490196, a: 1}
+  m_SelectedPrefabTextColor: {r: 0.382199, g: 0.60733, b: 1, a: 1}
   m_StackingFraction: 0.3
 --- !u!114 &114000011951837648
 MonoBehaviour:

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
@@ -46,11 +46,21 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		[SerializeField]
 		Color m_SelectedColor;
 
+		[SerializeField]
+		Color m_SelectedHoverColor;
+
+		[SerializeField]
+		Color m_PrefabTextColor;
+
+		[SerializeField]
+		Color m_SelectedPrefabTextColor;
+
 		[Tooltip("The fraction of the cube height to use for stacking grabbed rows")]
 		[SerializeField]
 		float m_StackingFraction = 0.3f;
 
 		Color m_NormalColor;
+		Color m_NormalTextColor;
 		Renderer m_CubeRenderer;
 		Transform m_CubeTransform;
 		Transform m_DropZoneTransform;
@@ -134,6 +144,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 				m_DropZone.canDrop = CanDrop;
 				m_DropZone.receiveDrop = ReceiveDrop;
 				m_DropZone.getDropObject = GetDropObject;
+
+				m_NormalTextColor = m_Text.color;
 			}
 
 			m_CubeTransform = m_Cube.transform;
@@ -191,13 +203,23 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			UpdateArrow(expanded);
 
+			var isPrefab = PrefabUtility.GetPrefabType(data.gameObject) == PrefabType.PrefabInstance;
 			// Set selected/hover/normal color
-			if (hovering)
+			if (selected)
+			{
+				cubeMaterial.color = hovering ? m_SelectedHoverColor : m_SelectedColor;
+				m_Text.color = isPrefab ? m_SelectedPrefabTextColor : m_NormalTextColor;
+			}
+			else if (hovering)
+			{
 				cubeMaterial.color = m_HoverColor;
-			else if (selected)
-				cubeMaterial.color = m_SelectedColor;
+				m_Text.color = isPrefab ? m_PrefabTextColor : m_NormalTextColor;
+			}
 			else
+			{
 				cubeMaterial.color = m_NormalColor;
+				m_Text.color = isPrefab ? m_PrefabTextColor : m_NormalTextColor;
+			}
 		}
 
 		public void UpdateArrow(bool? expanded, bool immediate = false)


### PR DESCRIPTION
### Purpose of this PR
Set text color in hierarchy to blue for prefabs. Also adds a selected-and-hovered state because otherwise there was no hover for the selected object.

### Testing status
Tested in Polygon Adventure scene with a few prefabs in the root

### Technical risk
None

### Comments to reviewers
Forgot to get to this one before lunch. I had to reduce the brightness of the hover color slightly to make the blue text readable on hover.