### PR TITLE
Skinned Mesh Hotfix

### DIFF
--- a/Scripts/Modules/IntersectionModule/IntersectionModule.cs
+++ b/Scripts/Modules/IntersectionModule/IntersectionModule.cs
@@ -38,6 +38,11 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			public float distance;
 		}
 
+		void Awake()
+		{
+			IntersectionUtils.BakedMesh = new Mesh(); // Create a new Mesh in each Awake because it is destroyed on scene load
+		}
+
 		internal void Setup(SpatialHash<Renderer> hash)
 		{
 			m_SpatialHash = hash;

--- a/Scripts/Utilities/IntersectionUtils.cs
+++ b/Scripts/Utilities/IntersectionUtils.cs
@@ -8,7 +8,7 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 	{
 		// Local method use only -- created here to reduce garbage collection
 		static readonly Vector3[] k_TriangleVertices = new Vector3[3];
-		static readonly Mesh k_BakedMesh = new Mesh();
+		public static Mesh BakedMesh { private get; set; }
 
 		/// <summary>
 		/// Test whether an object collides with the tester
@@ -192,8 +192,8 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 				var smr = obj.GetComponent<SkinnedMeshRenderer>();
 				if (smr)
 				{
-					smr.BakeMesh(k_BakedMesh);
-					collisionTester.sharedMesh = k_BakedMesh;
+					smr.BakeMesh(BakedMesh);
+					collisionTester.sharedMesh = BakedMesh;
 				}
 			}
 		}


### PR DESCRIPTION
### Purpose of this PR
Fix a bug introduced by #245 where the static k_BakedMesh object gets destroyed on scene load and causes errors next time EVR is run.

### Testing status
Tested in a scene with a skinned mesh. In current development:

1. Compile scripts
2. Change scenes to something with a skinned mesh
3. Run EVR and hover over the skinned mesh

You will see MissingReferenceExceptions spamming the console. This branch should fix this.

### Technical risk
Low; Only an issue if IntersectionUtils is used without IntersectionModule

### Comments to reviewers
I guess static references appear to the scene load as leaked meshes