### PR TITLE
World Scale Performance Fixes

### DIFF
--- a/Scripts/Core/EditorVR.MiniWorlds.cs
+++ b/Scripts/Core/EditorVR.MiniWorlds.cs
@@ -177,6 +177,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
 			bool m_MiniWorldIgnoreListDirty = true;
 
+			// Local method use only -- created here to reduce garbage collection
+			readonly List<Renderer> m_IgnoreList = new List<Renderer>();
+
 			public Dictionary<Transform, MiniWorldRay> rays { get { return m_Rays; } }
 			public List<IMiniWorld> worlds { get { return m_Worlds; } }
 
@@ -225,8 +228,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
 			void UpdateMiniWorldIgnoreList()
 			{
-				var renderers = new List<Renderer>(evr.GetComponentsInChildren<Renderer>(true));
-				var ignoreList = new List<Renderer>(renderers.Count);
+				var renderers = evr.GetComponentsInChildren<Renderer>(true);
+				m_IgnoreList.Clear();
 
 				foreach (var r in renderers)
 				{
@@ -236,12 +239,12 @@ namespace UnityEditor.Experimental.EditorVR.Core
 					if (r.gameObject.layer != LayerMask.NameToLayer("UI") && r.CompareTag(MiniWorldRenderer.ShowInMiniWorldTag))
 						continue;
 
-					ignoreList.Add(r);
+					m_IgnoreList.Add(r);
 				}
 
 				foreach (var miniWorld in m_Worlds)
 				{
-					miniWorld.ignoreList = ignoreList;
+					miniWorld.ignoreList = m_IgnoreList;
 				}
 			}
 

--- a/Scripts/Data/HierarchyData.cs
+++ b/Scripts/Data/HierarchyData.cs
@@ -21,13 +21,11 @@ namespace UnityEditor.Experimental.EditorVR
 
 		public HashSet<string> types { get; set; }
 
-
-		public HierarchyData(HierarchyProperty property, HashSet<string> types)
+		public HierarchyData(HierarchyProperty property)
 		{
 			template = k_TemplateName;
 			name = property.name;
 			instanceID = property.instanceID;
-			this.types = types;
 		}
 	}
 }

--- a/Scripts/Data/HierarchyData.cs
+++ b/Scripts/Data/HierarchyData.cs
@@ -29,29 +29,6 @@ namespace UnityEditor.Experimental.EditorVR
 			instanceID = property.instanceID;
 			this.types = types;
 		}
-
-		//public HierarchyData(string name, int instanceID, HashSet<string> types, List<HierarchyData> children = null)
-		//{
-		//	template = k_TemplateName;
-		//	this.name = name;
-		//	this.instanceID = instanceID;
-		//	this.types = types;
-		//	m_Children = children;
-		//}
-
-		public void Print(int depth = 0)
-		{
-			var log = name;
-			for (var i = 0; i < depth; i++)
-			{
-				log = "    " + log;
-			}
-			Debug.Log(depth + ": " + log);
-
-			if (children != null)
-				foreach (var hierarchyData in children)
-					hierarchyData.Print(depth + 1);
-		}
 	}
 }
 #endif

--- a/Scripts/Data/HierarchyData.cs
+++ b/Scripts/Data/HierarchyData.cs
@@ -21,13 +21,13 @@ namespace UnityEditor.Experimental.EditorVR
 
 		public HashSet<string> types { get; set; }
 
-		public HierarchyData(string name, int instanceID, HashSet<string> types, List<HierarchyData> children = null)
+
+		public HierarchyData(HierarchyProperty property, HashSet<string> types)
 		{
 			template = k_TemplateName;
-			this.name = name;
-			this.instanceID = instanceID;
+			name = property.name;
+			instanceID = property.instanceID;
 			this.types = types;
-			m_Children = children;
 		}
 	}
 }

--- a/Scripts/Data/HierarchyData.cs
+++ b/Scripts/Data/HierarchyData.cs
@@ -29,6 +29,29 @@ namespace UnityEditor.Experimental.EditorVR
 			instanceID = property.instanceID;
 			this.types = types;
 		}
+
+		//public HierarchyData(string name, int instanceID, HashSet<string> types, List<HierarchyData> children = null)
+		//{
+		//	template = k_TemplateName;
+		//	this.name = name;
+		//	this.instanceID = instanceID;
+		//	this.types = types;
+		//	m_Children = children;
+		//}
+
+		public void Print(int depth = 0)
+		{
+			var log = name;
+			for (var i = 0; i < depth; i++)
+			{
+				log = "    " + log;
+			}
+			Debug.Log(depth + ": " + log);
+
+			if (children != null)
+				foreach (var hierarchyData in children)
+					hierarchyData.Print(depth + 1);
+		}
 	}
 }
 #endif

--- a/Scripts/Modules/HierarchyModule.cs
+++ b/Scripts/Modules/HierarchyModule.cs
@@ -1,5 +1,4 @@
 ﻿#if UNITY_EDITOR
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -8,6 +7,8 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 {
 	sealed class HierarchyModule : MonoBehaviour, ISelectionChanged
 	{
+		readonly string[] k_IgnoredTypes = { "InputManager", "EditingContextManager" };
+
 		readonly List<IUsesHierarchyData> m_HierarchyLists = new List<IUsesHierarchyData>();
 		readonly List<HierarchyData> m_HierarchyData = new List<HierarchyData>();
 		HierarchyProperty m_HierarchyProperty;
@@ -66,21 +67,27 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 		void UpdateHierarchyData()
 		{
 			m_ObjectTypes.Clear();
-			m_HierarchyData.Clear();
 
 			if (m_HierarchyProperty == null)
 				m_HierarchyProperty = new HierarchyProperty(HierarchyType.GameObjects);
 			else
 				m_HierarchyProperty.Reset();
 
+			//Debug.Log("update");
+
+			var hasChanged = false;
 			var lastDepth = 0;
-			var stack = new Stack<HierarchyData>();
+			var dataStack = new Stack<HierarchyData>();
+			var siblingIndexStack = new Stack<int>();
+			dataStack.Push(null);
+			siblingIndexStack.Push(0);
 			while (m_HierarchyProperty.Next(null))
 			{
 				var instanceID = m_HierarchyProperty.instanceID;
+				var types = InstanceIDToComponentTypes(instanceID, m_ObjectTypes);
 				var go = EditorUtility.InstanceIDToObject(instanceID);
 				var currentDepth = m_HierarchyProperty.depth;
-				if (go == gameObject)
+				if (go == gameObject || types.Overlaps(k_IgnoredTypes))
 				{
 					var depth = currentDepth;
 					// skip children of EVR to prevent the display of EVR contents
@@ -93,48 +100,232 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 						break;
 				}
 
-				var types = InstanceIDToComponentTypes(instanceID, m_ObjectTypes);
-				var currentHierarchyData = new HierarchyData(m_HierarchyProperty, types);
+				//if (currentDepth > lastDepth)
+				//	siblingIndexStack.Push(0);
 
-				HierarchyData parent = null;
 				if (currentDepth <= lastDepth)
 				{
-					// Add one to pop off last sibling
-					var count = lastDepth - currentDepth + 1;
-					while (count-- > 0 && stack.Count > 0)
+					//Debug.Log(dataStack.Count);
+					if (dataStack.Count > 1) // Pop off last sibling
 					{
-						stack.Pop();
+						if (CleanUpHierarchyData(dataStack.Pop(), siblingIndexStack.Pop()))
+							hasChanged = true;
+					}
+
+					//if (currentDepth < lastDepth)
+					//{
+					//	if (CleanUpHierarchyData(dataStack.Peek(), siblingIndexStack.Peek()))
+					//		hasChanged = true;
+					//	//var lastParent = dataStack.Peek();
+					//	//var lastChildren = lastParent == null ? m_HierarchyData : lastParent.children;
+					//	//var lastSiblingIndex = siblingIndexStack.Peek();
+					//	//var childrenCount = lastChildren.Count;
+					//	//if (lastSiblingIndex != childrenCount)
+					//	//{
+					//	//	lastChildren.RemoveRange(lastSiblingIndex, childrenCount - lastSiblingIndex);
+					//	//	hasChanged = true;
+					//	//}
+					//}
+
+					var count = lastDepth - currentDepth;
+					while (count-- > 0)
+					{
+						if (CleanUpHierarchyData(dataStack.Pop(), siblingIndexStack.Pop()))
+							hasChanged = true;
 					}
 				}
 
-				if (stack.Count > 0)
-					parent = stack.Peek();
+				var parent = dataStack.Peek();
+				var siblingIndex = siblingIndexStack.Pop();
 
-				if (parent != null)
+				//var log = m_HierarchyProperty.name;
+				//for (var i = 0; i < m_HierarchyProperty.depth; i++)
+				//{
+				//	log = "    " + log;
+				//}
+				//Debug.Log(lastDepth + " - " + currentDepth + "(" + siblingIndex + "): " + log);
+
+				if (parent != null && parent.children == null)
+					parent.children = new List<HierarchyData>();
+
+				var children = parent == null ? m_HierarchyData : parent.children;
+
+				HierarchyData currentHierarchyData;
+				if (siblingIndex >= children.Count)
 				{
-					if (parent.children == null)
-						parent.children = new List<HierarchyData>();
-					parent.children.Add(currentHierarchyData);
+					currentHierarchyData = new HierarchyData(m_HierarchyProperty, types);
+					children.Add(currentHierarchyData);
+					hasChanged = true;
+				}
+				else if (children[siblingIndex].index != instanceID)
+				{
+					currentHierarchyData = new HierarchyData(m_HierarchyProperty, types);
+					children[siblingIndex] = currentHierarchyData;
+					hasChanged = true;
 				}
 				else
 				{
-					m_HierarchyData.Add(currentHierarchyData);
+					currentHierarchyData = children[siblingIndex];
+
+					if (!currentHierarchyData.types.SetEquals(types))
+						hasChanged = true;
+
+					currentHierarchyData.types = types; // In case of added components
 				}
 
-				stack.Push(currentHierarchyData);
+				dataStack.Push(currentHierarchyData);
+				siblingIndexStack.Push(siblingIndex + 1);
+				siblingIndexStack.Push(0);
 				lastDepth = currentDepth;
 			}
 
-			foreach (var list in m_HierarchyLists)
+			while (siblingIndexStack.Count > 0 && dataStack.Count > 0)
 			{
-				list.hierarchyData = GetHierarchyData();
+				if (CleanUpHierarchyData(dataStack.Pop(), siblingIndexStack.Pop()))
+					hasChanged = true;
+
+				//var siblingIndex = siblingIndexStack.Pop();
+				//HierarchyData parent = null;
+				//if (dataStack.Count > 0)
+				//	parent = dataStack.Pop();
+				//Debug.Log(siblingIndex + ", " + (parent == null ? "no parent" : parent.name));
+				//var children = parent == null ? m_HierarchyData : parent.children;
+				//if (children != null)
+				//{
+				//	var childrenCount = children.Count;
+				//	Debug.Log(siblingIndex + ", " + childrenCount);
+				//	if (siblingIndex != childrenCount)
+				//	{
+				//		children.RemoveRange(siblingIndex, childrenCount - siblingIndex);
+				//		hasChanged = true;
+				//	}
+
+				//	if (parent != null && children.Count == 0)
+				//		parent.children = null;
+				//}
 			}
 
-			// Send new data to existing filterUIs
-			foreach (var filterUI in m_FilterUIs)
+			//foreach (var hierarchyData in m_HierarchyData)
+			//{
+			//	hierarchyData.Print();
+			//}
+
+			if (hasChanged)
 			{
-				filterUI.filterList = GetFilterList();
+				Debug.Log("change");
+				foreach (var list in m_HierarchyLists)
+				{
+					list.hierarchyData = GetHierarchyData();
+				}
+
+				// Send new data to existing filterUIs
+				foreach (var filterUI in m_FilterUIs)
+				{
+					filterUI.filterList = GetFilterList();
+				}
 			}
+		}
+
+		//HierarchyData CollectHierarchyData(HierarchyProperty hp, HashSet<string> objectTypes)
+		//{
+		//	var depth = hp.depth;
+		//	var name = hp.name;
+		//	var instanceID = hp.instanceID;
+		//	var types = InstanceIDToComponentTypes(instanceID, objectTypes);
+
+		//	Stack<HierarchyData> stack = new Stack<HierarchyData>();
+		//	if (hp.hasChildren)
+		//	{
+		//		if (hd != null && hd.children == null)
+		//			hasChanged = true;
+
+		//		children = hd == null || hd.children == null ? new List<HierarchyData>() : hd.children;
+
+		//		hasNext = hp.Next(null);
+		//		var i = 0;
+		//		while (hasNext && hp.depth > depth)
+		//		{
+		//			var go = EditorUtility.InstanceIDToObject(hp.instanceID);
+
+		//			if (go == gameObject)
+		//			{
+		//				// skip children of EVR to prevent the display of EVR contents
+		//				while (hp.Next(null) && hp.depth > depth + 1) { }
+
+		//				// If EVR is the last object, don't add anything to the list
+		//				if (hp.instanceID == 0)
+		//					break;
+
+		//				name = hp.name;
+		//				instanceID = hp.instanceID;
+		//				types = InstanceIDToComponentTypes(instanceID, objectTypes);
+		//			}
+
+		//			if (i >= children.Count)
+		//			{
+		//				children.Add(CollectHierarchyData(ref hasNext, ref hasChanged, null, hp, objectTypes));
+		//				hasChanged = true;
+		//			}
+		//			else if (children[i].index != hp.instanceID)
+		//			{
+		//				children[i] = CollectHierarchyData(ref hasNext, ref hasChanged, null, hp, objectTypes);
+		//				hasChanged = true;
+		//			}
+		//			else
+		//			{
+		//				children[i] = CollectHierarchyData(ref hasNext, ref hasChanged, children[i], hp, objectTypes);
+		//			}
+
+		//			if (hasNext)
+		//				hasNext = hp.Next(null);
+
+		//			i++;
+		//		}
+
+		//		if (i != children.Count)
+		//		{
+		//			children.RemoveRange(i, children.Count - i);
+		//			hasChanged = true;
+		//		}
+
+		//		if (children.Count == 0)
+		//			children = null;
+
+		//		if (hasNext)
+		//			hp.Previous(null);
+		//	}
+		//	else if (hd != null && hd.children != null)
+		//	{
+		//		hasChanged = true;
+		//	}
+
+		//	if (hd != null)
+		//	{
+		//		hd.children = children;
+		//		hd.name = name;
+		//		hd.instanceID = instanceID;
+		//		hd.types = types;
+		//	}
+
+		//	return hd ?? new HierarchyData(name, instanceID, types, children);
+		//}
+
+		bool CleanUpHierarchyData(HierarchyData data, int lastSiblingIndex)
+		{
+			var children = data == null ? m_HierarchyData : data.children;
+			var childrenCount = children == null ? 0 : children.Count;
+			//Debug.Log(name + ", " + childrenCount + " - " + lastSiblingIndex);
+
+			if (children != null && lastSiblingIndex < childrenCount)
+			{
+				children.RemoveRange(lastSiblingIndex, childrenCount - lastSiblingIndex);
+				if (data != null && children.Count == 0)
+					data.children = null;
+
+				return true;
+			}
+
+			return false;
 		}
 
 		static HashSet<string> InstanceIDToComponentTypes(int instanceID, HashSet<string> allTypes)
@@ -144,8 +335,10 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			if (go)
 			{
 				var components = go.GetComponents<Component>();
-				foreach (var component in components)
+				for (int i = 0; i < components.Length; i++)
 				{
+					var component = components[i];
+
 					if (!component)
 						continue;
 

--- a/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
+++ b/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
@@ -106,8 +106,12 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			m_EventCamera.nearClipPlane = camera.nearClipPlane;
 			m_EventCamera.farClipPlane = camera.farClipPlane;
 
+			// The sources dictionary can change during iteration, so cache it before iterating
 			m_RaycastSourcesCopy.Clear();
-			m_RaycastSourcesCopy.AddRange(m_RaycastSources.Values); // The sources dictionary can change during iteration, so cache it before iterating
+			foreach (var kvp in m_RaycastSources)
+			{
+				m_RaycastSourcesCopy.Add(kvp.Value);
+			}
 
 			//Process events for all different transforms in RayOrigins
 			foreach (var source in m_RaycastSourcesCopy)

--- a/Scripts/Proxies/DefaultProxyRay.cs
+++ b/Scripts/Proxies/DefaultProxyRay.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using UnityEngine;
 using UnityEditor.Experimental.EditorVR.Extensions;
+using UnityEditor.Experimental.EditorVR.Modules;
 using UnityEditor.Experimental.EditorVR.Utilities;
 
 namespace UnityEditor.Experimental.EditorVR.Proxies
@@ -27,6 +28,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 		Coroutine m_RayVisibilityCoroutine;
 		Coroutine m_ConeVisibilityCoroutine;
 		Material m_RayMaterial;
+		IntersectionTester m_Tester;
 
 		/// <summary>
 		/// The object that is set when LockRay is called while the ray is unlocked.
@@ -145,6 +147,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 			m_RayMaterial = MaterialUtils.GetMaterialClone(m_LineRenderer.GetComponent<MeshRenderer>());
 			m_ConeTransform = m_Cone.transform;
 			m_OriginalConeLocalScale = m_ConeTransform.localScale;
+			m_Tester = GetComponentInChildren<IntersectionTester>();
 		}
 
 		private void Start()
@@ -203,6 +206,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 
 		IEnumerator HideCone()
 		{
+			m_Tester.active = false;
 			var currentScale = m_ConeTransform.localScale;
 			var smoothVelocity = Vector3.one;
 			const float kSmoothTime = 0.1875f;
@@ -235,6 +239,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 
 			m_ConeTransform.localScale = m_OriginalConeLocalScale;
 			m_ConeVisibilityCoroutine = null;
+			m_Tester.active = true;
 		}
 
 		void OnDestroy()

--- a/Scripts/Utilities/CameraUtils.cs
+++ b/Scripts/Utilities/CameraUtils.cs
@@ -65,9 +65,10 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 		/// </summary>
 		/// <param name="parentRotation">Glboal rotation of the parent transform</param>
 		/// <returns></returns>
-		public static Quaternion LocalRotateTowardCamera(Quaternion parentRotation)
+		public static Quaternion LocalRotateTowardCamera(Transform parentTransform)
 		{
-			var camVector = Quaternion.Inverse(parentRotation) * GetMainCamera().transform.forward;
+			var toCamera = parentTransform.position - GetMainCamera().transform.position;
+			var camVector = Quaternion.Inverse(parentTransform.rotation) * toCamera;
 			camVector.x = 0;
 			return Quaternion.LookRotation(camVector, Vector3.Dot(camVector, Vector3.forward) > 0 ? Vector3.up : Vector3.down);
 		}

--- a/Workspaces/Common/Materials/ListItemClip.mat
+++ b/Workspaces/Common/Materials/ListItemClip.mat
@@ -72,6 +72,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _ClipExtents: {r: 1, g: 1, b: 1, a: 0}
+    - _ClipExtents: {r: 236.22, g: 96.42, b: 92.61, a: 2.29}
     - _Color: {r: 0.101960786, g: 0.101960786, b: 0.101960786, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Workspaces/HierarchyWorkspace/Prefabs/HierarchyListItem.prefab
+++ b/Workspaces/HierarchyWorkspace/Prefabs/HierarchyListItem.prefab
@@ -227,13 +227,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1407269964740084}
-  m_LocalRotation: {x: -0.14110889, y: -0.38632697, z: 0.32493064, w: 0.8516219}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0.40332916, y: -0.32925647, z: 0.44692823, w: 0.72744143}
+  m_LocalPosition: {x: -0.089, y: 0, z: 0}
   m_LocalScale: {x: 0.7698965, y: 0.76989645, z: 0.7698965}
   m_Children: []
   m_Father: {fileID: 4915716757996668}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0.614, y: -48.569, z: 41.491}
+  m_LocalEulerAnglesHint: {x: -17.007, y: -61.395, z: 73.277}
 --- !u!4 &4915716757996668
 Transform:
   m_ObjectHideFlags: 1
@@ -577,7 +577,7 @@ MonoBehaviour:
   m_FontData:
     m_Font: {fileID: 12800000, guid: 013679fd6ee2085428a7f896aa7b50cc, type: 3}
     m_FontSize: 14
-    m_FontStyle: 0
+    m_FontStyle: 1
     m_BestFit: 0
     m_MinSize: 7
     m_MaxSize: 300
@@ -703,6 +703,6 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.033125866, y: 0.008}
+  m_AnchoredPosition: {x: -0.033125866, y: 0.008000001}
   m_SizeDelta: {x: 70.0878, y: 20}
   m_Pivot: {x: 0, y: 0.5}

--- a/Workspaces/HierarchyWorkspace/Prefabs/HierarchyListItem.prefab
+++ b/Workspaces/HierarchyWorkspace/Prefabs/HierarchyListItem.prefab
@@ -41,7 +41,7 @@ GameObject:
   - component: {fileID: 222000012560431470}
   - component: {fileID: 114000013632537286}
   m_Layer: 5
-  m_Name: Text
+  m_Name: SceneText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -120,6 +120,55 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1407269964740084
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4149368731521994}
+  - component: {fileID: 33251685153113494}
+  - component: {fileID: 23280758573819164}
+  m_Layer: 0
+  m_Name: SceneIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1522722938377154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224115672245688706}
+  - component: {fileID: 222608860966768846}
+  - component: {fileID: 114433554785773084}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1668105077605892
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4915716757996668}
+  m_Layer: 0
+  m_Name: SceneIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!4 &4000012112020226
 Transform:
   m_ObjectHideFlags: 1
@@ -131,7 +180,7 @@ Transform:
   m_LocalScale: {x: 0.1, y: 0.005, z: 0.016}
   m_Children: []
   m_Father: {fileID: 224000012423797820}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013103477036
 Transform:
@@ -157,7 +206,7 @@ Transform:
   m_LocalScale: {x: 0.02, y: 0.02, z: 0.02}
   m_Children: []
   m_Father: {fileID: 224000012423797820}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000014207549962
 Transform:
@@ -170,8 +219,35 @@ Transform:
   m_LocalScale: {x: 0.015, y: 0.015, z: 0.2}
   m_Children: []
   m_Father: {fileID: 224000012423797820}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!4 &4149368731521994
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1407269964740084}
+  m_LocalRotation: {x: -0.14110889, y: -0.38632697, z: 0.32493064, w: 0.8516219}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7698965, y: 0.76989645, z: 0.7698965}
+  m_Children: []
+  m_Father: {fileID: 4915716757996668}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0.614, y: -48.569, z: 41.491}
+--- !u!4 &4915716757996668
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1668105077605892}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.0243, y: 0.008, z: 0.0003}
+  m_LocalScale: {x: 0.016412389, y: 0.01641238, z: 0.016412381}
+  m_Children:
+  - {fileID: 4149368731521994}
+  m_Father: {fileID: 224000012423797820}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &23000010055392968
 MeshRenderer:
   m_ObjectHideFlags: 1
@@ -300,6 +376,39 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!23 &23280758573819164
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1407269964740084}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 3ac4991e69337ae41badfeef7c8ba134, type: 2}
+  - {fileID: 2100000, guid: d3bb23d585e936140a5f274d7450f24e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!33 &33000010220856868
 MeshFilter:
   m_ObjectHideFlags: 1
@@ -328,6 +437,13 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000013287519124}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &33251685153113494
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1407269964740084}
+  m_Mesh: {fileID: 4300000, guid: 4f59d2c28d92b4a0486ef9a7530a7236, type: 3}
 --- !u!65 &65000010297142882
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -399,10 +515,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3bf7c67220198eb46888299659a385ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Text: {fileID: 114000013632537286}
+  m_Text: {fileID: 114433554785773084}
+  m_SceneText: {fileID: 114000013632537286}
   m_Lock: {fileID: 114000011118187708}
   m_Cube: {fileID: 114000012425087266}
   m_ExpandArrow: {fileID: 114000011951837648}
+  m_SceneIcon: {fileID: 4915716757996668}
   m_DropZone: {fileID: 114000014220381596}
   m_NoClipExpandArrow: {fileID: 2100000, guid: d066c89af6b2b864cb02f409d89ce3ba, type: 2}
   m_NoClipBackingCube: {fileID: 2100000, guid: 1a070009f7968b74abbf1a1ae823b472, type: 2}
@@ -482,12 +600,51 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_SelectionFlags: 3
+--- !u!114 &114433554785773084
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1522722938377154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 2569ce4f009c407448c0df4aa8d7db55, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 013679fd6ee2085428a7f896aa7b50cc, type: 3}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 7
+    m_MaxSize: 300
+    m_Alignment: 3
+    m_AlignByGeometry: 1
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Test Text
 --- !u!222 &222000012560431470
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012579815556}
+--- !u!222 &222608860966768846
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1522722938377154}
 --- !u!224 &224000012423797820
 RectTransform:
   m_ObjectHideFlags: 1
@@ -499,7 +656,9 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4000013103477036}
+  - {fileID: 224115672245688706}
   - {fileID: 224000013671661884}
+  - {fileID: 4915716757996668}
   - {fileID: 4000014207549962}
   - {fileID: 4000012112020226}
   - {fileID: 4000013634378948}
@@ -508,7 +667,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -334, y: -97}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0.1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000013671661884
@@ -519,6 +678,24 @@ RectTransform:
   m_GameObject: {fileID: 1000012579815556}
   m_LocalRotation: {x: 0.38268343, y: -0, z: -0, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.0009999999, y: 0.0009999999, z: 0.0009999999}
+  m_Children: []
+  m_Father: {fileID: 224000012423797820}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.0141, y: 0.0079956055}
+  m_SizeDelta: {x: 51.1145, y: 20}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!224 &224115672245688706
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1522722938377154}
+  m_LocalRotation: {x: 0.38268343, y: -0, z: -0, w: 0.92387956}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
   m_Children: []
   m_Father: {fileID: 224000012423797820}
@@ -527,5 +704,5 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -0.033125866, y: 0.008}
-  m_SizeDelta: {x: 80, y: 20}
+  m_SizeDelta: {x: 70.0878, y: 20}
   m_Pivot: {x: 0, y: 0.5}

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
@@ -20,6 +20,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		Text m_Text;
 
 		[SerializeField]
+		Text m_SceneText;
+
+		[SerializeField]
 		BaseHandle m_Lock;
 
 		[SerializeField]
@@ -27,6 +30,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		[SerializeField]
 		BaseHandle m_ExpandArrow;
+
+		[SerializeField]
+		Transform m_SceneIcon;
 
 		[SerializeField]
 		BaseHandle m_DropZone;
@@ -77,7 +83,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		Material m_LockIconMaterial;
 		Material m_UnlockIconMaterial;
 
-		bool m_HoveringLock = false;
+		bool m_HoveringLock;
 
 		public bool hovering { get; private set; }
 		public Transform hoveringRayOrigin { get; private set; }
@@ -150,7 +156,22 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			m_CubeTransform = m_Cube.transform;
 			m_DropZoneTransform = m_DropZone.transform;
-			m_Text.text = data.name;
+
+			var name = data.name;
+			if (data.gameObject == null)
+			{
+				m_SceneText.text = string.IsNullOrEmpty(name) ? "Untitled" : name;
+				m_SceneIcon.gameObject.SetActive(true);
+				m_SceneText.gameObject.SetActive(true);
+				m_Text.gameObject.SetActive(false);
+			}
+			else
+			{
+				m_Text.text = name;
+				m_SceneIcon.gameObject.SetActive(false);
+				m_SceneText.gameObject.SetActive(false);
+				m_Text.gameObject.SetActive(true);
+			}
 
 			hovering = false;
 		}
@@ -158,6 +179,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 		public void SetMaterials(Material textMaterial, Material expandArrowMaterial, Material lockIconMaterial, Material unlockIconMaterial)
 		{
 			m_Text.material = textMaterial;
+			m_SceneText.material = textMaterial;
 			m_ExpandArrowMaterial = expandArrowMaterial;
 			m_ExpandArrowRenderer.sharedMaterial = expandArrowMaterial;
 			m_LockIconMaterial = lockIconMaterial;
@@ -182,17 +204,24 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			m_LockRenderer.sharedMaterial = (!locked && m_HoveringLock) || (locked && !m_HoveringLock) ? m_LockIconMaterial : m_UnlockIconMaterial;
 			var lockIconTransform = m_Lock.transform;
 			var lockWidth = lockIconTransform.localScale.x * 0.5f;
-			
-			// Text is next to arrow, with a margin and indent, rotated toward camera
-			var textTransform = m_Text.transform;
-			m_Text.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, (width - doubleMargin - indent) * 1 / textTransform.localScale.x);
-			textTransform.localPosition = new Vector3(doubleMargin + indent + arrowWidth - halfWidth, textTransform.localPosition.y, 0);
 
+			// Text is next to arrow, with a margin and indent, rotated toward camera
+			var gameObject = data.gameObject;
+			if (gameObject == null)
+				indent = k_Indent * 2;
+
+			var textTransform = gameObject ? m_Text.transform : m_SceneText.transform;
+			var textRectTransform = gameObject ? m_Text.rectTransform : m_SceneText.rectTransform;
+			textRectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, (width - doubleMargin - indent) * 1 / textTransform.localScale.x);
+			textTransform.localPosition = new Vector3(doubleMargin + indent + arrowWidth - halfWidth, textTransform.localPosition.y, 0);
 			lockIconTransform.localPosition = new Vector3(halfWidth - lockWidth - k_Margin, lockIconTransform.localPosition.y, 0);
+			var sceneIconPosition = m_SceneIcon.localPosition;
+			m_SceneIcon.localPosition = new Vector3(-halfWidth + k_Margin + arrowWidth + k_Indent, sceneIconPosition.y, sceneIconPosition.z);
 
 			var localRotation = CameraUtils.LocalRotateTowardCamera(transform.parent.rotation);
 			textTransform.localRotation = localRotation;
 			lockIconTransform.localRotation = localRotation;
+			m_SceneIcon.localRotation = localRotation;
 
 			var dropZoneScale = m_DropZoneTransform.localScale;
 			dropZoneScale.x = width - indent;
@@ -203,7 +232,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			UpdateArrow(expanded);
 
-			var isPrefab = PrefabUtility.GetPrefabType(data.gameObject) == PrefabType.PrefabInstance;
+			var isPrefab = gameObject && PrefabUtility.GetPrefabType(gameObject) == PrefabType.PrefabInstance;
 			// Set selected/hover/normal color
 			if (selected)
 			{

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
@@ -189,9 +189,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		public void UpdateSelf(float width, int depth, bool? expanded, bool selected, bool locked)
 		{
-			var childCount = data.children == null ? 0 : data.children.Count;
-			m_Text.text = data.name + "(" + childCount + ")";
-
 			var cubeScale = m_CubeTransform.localScale;
 			cubeScale.x = width;
 			m_CubeTransform.localScale = cubeScale;

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
@@ -189,6 +189,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		public void UpdateSelf(float width, int depth, bool? expanded, bool selected, bool locked)
 		{
+			var childCount = data.children == null ? 0 : data.children.Count;
+			m_Text.text = data.name + "(" + childCount + ")";
+
 			var cubeScale = m_CubeTransform.localScale;
 			cubeScale.x = width;
 			m_CubeTransform.localScale = cubeScale;
@@ -208,7 +211,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			// Text is next to arrow, with a margin and indent, rotated toward camera
 			var gameObject = data.gameObject;
 			if (gameObject == null)
-				indent = k_Indent * 2;
+				indent = k_Indent;
 
 			var textTransform = gameObject ? m_Text.transform : m_SceneText.transform;
 			var textRectTransform = gameObject ? m_Text.rectTransform : m_SceneText.rectTransform;
@@ -218,7 +221,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			var sceneIconPosition = m_SceneIcon.localPosition;
 			m_SceneIcon.localPosition = new Vector3(-halfWidth + k_Margin + arrowWidth + k_Indent, sceneIconPosition.y, sceneIconPosition.z);
 
-			var localRotation = CameraUtils.LocalRotateTowardCamera(transform.parent.rotation);
+			var localRotation = CameraUtils.LocalRotateTowardCamera(transform.parent);
 			textTransform.localRotation = localRotation;
 			lockIconTransform.localRotation = localRotation;
 			m_SceneIcon.localRotation = localRotation;

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListViewController.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListViewController.cs
@@ -59,7 +59,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 					// Expand the scenes by default
 					foreach (var scene in m_Data)
 					{
-						Debug.Log(scene);
 						var instanceID = scene.index;
 						if (!m_ExpandStates.ContainsKey(instanceID))
 							m_ExpandStates[instanceID] = true;

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListViewController.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListViewController.cs
@@ -41,6 +41,39 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 		readonly List<KeyValuePair<Transform, GameObject>> m_HoveredGameObjects = new List<KeyValuePair<Transform, GameObject>>();
 
+		public override List<HierarchyData> data
+		{
+			set
+			{
+				base.data = value;
+
+				if (m_Data != null && m_Data.Count > 0)
+				{
+					// Remove any objects that don't exist any more
+					var missingKeys = m_Data.Select(d => d.index).Except(m_ExpandStates.Keys);
+					foreach (var key in missingKeys)
+					{
+						m_ExpandStates.Remove(key);
+					}
+
+					// Expand the scenes by default
+					foreach (var scene in m_Data)
+					{
+						Debug.Log(scene);
+						var instanceID = scene.index;
+						if (!m_ExpandStates.ContainsKey(instanceID))
+							m_ExpandStates[instanceID] = true;
+					}
+
+					foreach (var d in m_Data)
+					{
+						if (!m_ExpandStates.ContainsKey(d.index))
+							m_ExpandStates[d.index] = false;
+					}
+				}
+			}
+		}
+
 		public string lockedQueryString { private get; set; }
 
 		public Action<int> selectRow { private get; set; }

--- a/Workspaces/ProjectWorkspace/Prefabs/SceneIcon.prefab
+++ b/Workspaces/ProjectWorkspace/Prefabs/SceneIcon.prefab
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1730059858115038}
+  m_IsPrefabParent: 1
+--- !u!1 &1730059858115038
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4767487945342266}
+  - component: {fileID: 33568172976101988}
+  - component: {fileID: 23990013054134058}
+  m_Layer: 0
+  m_Name: SceneIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4767487945342266
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1730059858115038}
+  m_LocalRotation: {x: -0.40333143, y: -0.32925728, z: 0.4469268, w: 0.72744066}
+  m_LocalPosition: {x: -0.0032085949, y: 0.009076677, z: 0.020639082}
+  m_LocalScale: {x: 0.7698965, y: 0.76989645, z: 0.7698965}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0.614, y: -48.569, z: 41.491}
+--- !u!23 &23990013054134058
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1730059858115038}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 3ac4991e69337ae41badfeef7c8ba134, type: 2}
+  - {fileID: 2100000, guid: d3bb23d585e936140a5f274d7450f24e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33568172976101988
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1730059858115038}
+  m_Mesh: {fileID: 4300000, guid: 4f59d2c28d92b4a0486ef9a7530a7236, type: 3}

--- a/Workspaces/ProjectWorkspace/Prefabs/SceneIcon.prefab.meta
+++ b/Workspaces/ProjectWorkspace/Prefabs/SceneIcon.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 35ccf65dc9572ec4db1bacd442eef72f
+timeCreated: 1500013172
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridItem.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridItem.cs
@@ -201,7 +201,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			transform.localScale = Vector3.one * scale;
 
-			m_TextPanel.transform.localRotation = CameraUtils.LocalRotateTowardCamera(transform.parent.rotation);
+			m_TextPanel.transform.localRotation = CameraUtils.LocalRotateTowardCamera(transform.parent);
 
 			if (m_Sphere.gameObject.activeInHierarchy)
 				m_Sphere.transform.Rotate(Vector3.up, k_RotateSpeed * Time.deltaTime, Space.Self);

--- a/Workspaces/ProjectWorkspace/Scripts/FolderListItem.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/FolderListItem.cs
@@ -104,7 +104,7 @@ namespace UnityEditor.Experimental.EditorVR.Data
 			m_Text.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, (width - doubleMargin - indent) * 1 / textTransform.localScale.x);
 			textTransform.localPosition = new Vector3(doubleMargin + indent + arrowWidth - halfWidth, textTransform.localPosition.y, 0);
 
-			textTransform.localRotation = CameraUtils.LocalRotateTowardCamera(transform.parent.rotation);
+			textTransform.localRotation = CameraUtils.LocalRotateTowardCamera(transform.parent);
 
 			UpdateArrow(expanded);
 


### PR DESCRIPTION
### Purpose of this PR
Improve the performance of hierarchy updates and intersection calls that were tanking performance while doing two-handed world scaling.

### Testing status
The issue was discovered in the Synty Airport Demo scene http://u3d.as/gpK

On Development the call to HierarchyChanged when you do world scaling takes 463ms, and on this branch it takes 110ms. This is still not ideal, so we might have to spread this out over a few frames like how the Project data is created. For now, however, I don't really notice the slowdown since this only happens once when the hierarchy is changed. The problem with doing the setup as a coroutine is that OnHierarchyChanged happens quite frequently, so we will need a way to either cancel the current, out-of-date process, or queue up change requests because they will likely occur during an existing traversal of the hierarchy. This might also not work if HierarchyProperty doesn't play nice with scene changes in the middle of a traversal.

Secondly, one of the biggest issues this change addresses is that, while scaling the world, the intersection module does a lot (~120/frame) of tests, presumably because the cone rays are all compressed down into a single point when they are hidden. The fix was simply to disable the tester when DefaultProxyRay hides the cone.

Between these two fixes (and a few other places where I got rid of GC allocation), performance in the Airport Demo scene is much, much better.

### Technical risk
Medium; This is a total rewrite of how we turn the HierarchyProperty into data for our workspace, so there may well be edge cases that we haven't tested for. I was quite thorough in my own testing while working on this and I think I have accounted for most types of hierarchies.

### Comments to reviewers
This turned into a bit of a rabbit hole, but it's a major improvement. That Airport scene isn't even that dense, but performance was awful. The code itself for parsing the hierarchy is a little cleaner and easier to understand as long as you are familiar with using a stack to unwind a recursive method.

I'm hoping this will also greatly improve performance with SceneFusion, but that's just a hunch.

Fixes #237 