### PR TITLE
add unit tests for common extension methods & utilities

### DIFF
--- a/Tests/Editor/Unit/Extension Methods.meta
+++ b/Tests/Editor/Unit/Extension Methods.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 020094575c74b3443afe5751ebe5e183
+folderAsset: yes
+timeCreated: 1500329146
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Extension Methods/MonoBehaviourExtensionsTests.cs
+++ b/Tests/Editor/Unit/Extension Methods/MonoBehaviourExtensionsTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEditor.Experimental.EditorVR.Extensions;
+using UnityEditor.Experimental.EditorVR.Proxies;
+
+namespace UnityEditor.Experimental.EditorVR.Tests.Extensions
+{
+    public class MonoBehaviourExtensionsTests
+    {
+        MonoBehaviour mb;
+        int coIndex = 0;
+        IEnumerator routine() { yield return coIndex++; }
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            mb = new GameObject().AddComponent<DefaultProxyRay>();
+        }
+
+        [Test]
+        public void StopCoroutineOverload_NullifiesCoroutine()
+        {
+            Coroutine coroutine = mb.StartCoroutine(routine());
+            Assert.IsNotNull(coroutine);
+            mb.StopCoroutine(ref coroutine);
+            Assert.IsNull(coroutine);
+        }
+    }
+}

--- a/Tests/Editor/Unit/Extension Methods/MonoBehaviourExtensionsTests.cs.meta
+++ b/Tests/Editor/Unit/Extension Methods/MonoBehaviourExtensionsTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6fc75e02c5521d94a93863239b592009
+timeCreated: 1500329146
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Extension Methods/TransformExtensionsTests.cs
+++ b/Tests/Editor/Unit/Extension Methods/TransformExtensionsTests.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+using UnityEditor.Experimental.EditorVR.Extensions;
+
+namespace UnityEditor.Experimental.EditorVR.Tests.Extensions
+{
+    [TestFixture]
+    public class TransformExtensionsTests
+    {
+        GameObject go;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            go = new GameObject();
+        }
+
+        [Test]
+        public void TransformBounds_TranslatesLocalBoundsToWorld()
+        {
+            var size = new Vector3(2, 2, 2);
+            var offset = new Vector3(1, 2, 3);
+            go.transform.position += offset;
+            var localBounds = new Bounds(go.transform.position, size);
+            var worldBounds = go.transform.TransformBounds(localBounds);
+
+            Assert.AreEqual(localBounds.center, worldBounds.center - offset);
+            Assert.AreEqual(localBounds.extents, worldBounds.extents);
+        }
+    }
+}

--- a/Tests/Editor/Unit/Extension Methods/TransformExtensionsTests.cs
+++ b/Tests/Editor/Unit/Extension Methods/TransformExtensionsTests.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Extensions
     public class TransformExtensionsTests
     {
         GameObject go;
+        float delta = 0.00000001f;
 
         [OneTimeSetUp]
         public void Setup()
@@ -21,11 +22,11 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Extensions
             var size = new Vector3(2, 2, 2);
             var offset = new Vector3(1, 2, 3);
             go.transform.position += offset;
-            var localBounds = new Bounds(go.transform.position, size);
-            var worldBounds = go.transform.TransformBounds(localBounds);
+            var local = new Bounds(go.transform.position, size);
+            var world = go.transform.TransformBounds(local);
 
-            Assert.AreEqual(localBounds.center, worldBounds.center - offset);
-            Assert.AreEqual(localBounds.extents, worldBounds.extents);
+            Assert.That(local.center, Is.EqualTo(world.center - offset).Within(delta));
+            Assert.That(local.extents, Is.EqualTo(world.extents).Within(delta));
         }
     }
 }

--- a/Tests/Editor/Unit/Extension Methods/TransformExtensionsTests.cs.meta
+++ b/Tests/Editor/Unit/Extension Methods/TransformExtensionsTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 882677a9c86d1fe41b1ba633d5492fa1
+timeCreated: 1500329146
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Extension Methods/Vec2ExtensionsTests.cs
+++ b/Tests/Editor/Unit/Extension Methods/Vec2ExtensionsTests.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+using UnityEditor.Experimental.EditorVR.Extensions;
+
+// MinComponent, MaxComponent, & Inverse are unused presently
+namespace UnityEditor.Experimental.EditorVR.Tests.Extensions
+{
+    [InitializeOnLoad]
+    public class Vec2ExtensionsTests
+    {
+        [Test]
+        public void Abs_NegativeValues_AreInverted()
+        {
+            Assert.AreEqual(new Vector2(2f, 1f), new Vector2(-2f, -1f).Abs());
+        }
+
+        [Test]
+        public void Abs_PositiveValues_AreUnchanged()
+        {
+            Assert.AreEqual(new Vector2(2f, 1f), new Vector2(2f, 1f).Abs());
+        }
+    }
+}

--- a/Tests/Editor/Unit/Extension Methods/Vec2ExtensionsTests.cs.meta
+++ b/Tests/Editor/Unit/Extension Methods/Vec2ExtensionsTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1551c5f8d457e1347898b759b29bae28
+timeCreated: 1500329146
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Extension Methods/Vec3ExtensionsTests.cs
+++ b/Tests/Editor/Unit/Extension Methods/Vec3ExtensionsTests.cs
@@ -7,6 +7,8 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Extensions
 {
     public class Vec3ExtensionsTests
     {
+        float delta = 0.00000001f;
+        
         [Test]
         public void MaxComponent_ReturnsMaxAxisValue()
         {
@@ -22,23 +24,25 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Extensions
         public void AveragedComponents()
         {
             var vec3 = new Vector3(4f, 2f, 6f);
-            Assert.AreEqual(vec3.AveragedComponents(), 4f);
+            Assert.That(vec3.AveragedComponents(), Is.EqualTo(4f).Within(delta));
             vec3 = new Vector3(-4f, 0f, 1f);
-            Assert.AreEqual(vec3.AveragedComponents(), -1f);
+            Assert.That(vec3.AveragedComponents(), Is.EqualTo(-1f).Within(delta));
         }
 
         [Test]
         public void Inverse_PositiveValues()
         {
             var vec3 = new Vector3(2f, 4f, 10f);
-            Assert.AreEqual(new Vector3(.5f, .25f, .1f), vec3.Inverse());
+            var expected = new Vector3(.5f, .25f, .1f);
+            Assert.That(vec3.Inverse(), Is.EqualTo(expected).Within(delta));
         }
 
         [Test]
         public void Inverse_NegativeValues()
         {
             var vec3 = new Vector3(-10f, -4f, -2f);
-            Assert.AreEqual(new Vector3(-.1f, -.25f, -.5f), vec3.Inverse());
+            var expected = new Vector3(-.1f, -.25f, -.5f);
+            Assert.That(vec3.Inverse(), Is.EqualTo(expected).Within(delta));
         }
 
     }

--- a/Tests/Editor/Unit/Extension Methods/Vec3ExtensionsTests.cs
+++ b/Tests/Editor/Unit/Extension Methods/Vec3ExtensionsTests.cs
@@ -1,0 +1,45 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+using UnityEditor.Experimental.EditorVR.Extensions;
+
+// MinComponent() has no uses in the project currently, so no test for it
+namespace UnityEditor.Experimental.EditorVR.Tests.Extensions
+{
+    public class Vec3ExtensionsTests
+    {
+        [Test]
+        public void MaxComponent_ReturnsMaxAxisValue()
+        {
+            var maxX = new Vector3(2f, 1f, 0f);
+            Assert.AreEqual(maxX.MaxComponent(), maxX.x);
+            var maxY = new Vector3(0f, 2f, 1f);
+            Assert.AreEqual(maxY.MaxComponent(), maxY.y);
+            var maxZ = new Vector3(0f, 1f, 2f);
+            Assert.AreEqual(maxZ.MaxComponent(), maxZ.z);
+        }
+
+        [Test]
+        public void AveragedComponents()
+        {
+            var vec3 = new Vector3(4f, 2f, 6f);
+            Assert.AreEqual(vec3.AveragedComponents(), 4f);
+            vec3 = new Vector3(-4f, 0f, 1f);
+            Assert.AreEqual(vec3.AveragedComponents(), -1f);
+        }
+
+        [Test]
+        public void Inverse_PositiveValues()
+        {
+            var vec3 = new Vector3(2f, 4f, 10f);
+            Assert.AreEqual(new Vector3(.5f, .25f, .1f), vec3.Inverse());
+        }
+
+        [Test]
+        public void Inverse_NegativeValues()
+        {
+            var vec3 = new Vector3(-10f, -4f, -2f);
+            Assert.AreEqual(new Vector3(-.1f, -.25f, -.5f), vec3.Inverse());
+        }
+
+    }
+}

--- a/Tests/Editor/Unit/Extension Methods/Vec3ExtensionsTests.cs.meta
+++ b/Tests/Editor/Unit/Extension Methods/Vec3ExtensionsTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f83fd35d544febe46b03a8fa48dc0000
+timeCreated: 1500329146
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Utilities.meta
+++ b/Tests/Editor/Unit/Utilities.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5854272062229354295787e9d34a4880
+folderAsset: yes
+timeCreated: 1500329146
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Utilities/GradientPairTests.cs
+++ b/Tests/Editor/Unit/Utilities/GradientPairTests.cs
@@ -1,0 +1,52 @@
+﻿using UnityEngine;
+using NUnit.Framework;
+using UnityEditor.Experimental.EditorVR.Helpers;
+
+namespace UnityEditor.Experimental.EditorVR.Tests.Utilities
+{
+    [TestFixture]
+    public class GradientPairTests
+    {
+        Color colorA, colorB, colorC, colorD, defaultColor;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            defaultColor = new Color(0f, 0f, 0f, 0f);
+            colorA = new Color(0.2f, 0.4f, 0.8f);
+            colorB = new Color(0.4f, 0.8f, 0.2f);
+            colorC = new Color(0.5f, 0.6f, 0.7f);
+            colorD = new Color(0.1f, 0.2f, 0.3f);
+        }
+
+        [Test]
+        public void Construct_Parameterless_HasDefaultColors()
+        {
+            var pair = new GradientPair();
+            Assert.AreEqual(defaultColor, pair.a);
+            Assert.AreEqual(defaultColor, pair.b);
+        }
+
+        [Test]
+        public void Construct_FromTwoColors()
+        {
+            var pair = new GradientPair(colorA, colorB);
+            Assert.AreEqual(colorA, pair.a);
+            Assert.AreEqual(colorB, pair.b);
+        }
+
+        [Test]
+        public void Lerp_Interpolates_StartAndEndColors()
+        {
+            var x = new GradientPair(colorA, colorB);
+            var y = new GradientPair(colorC, colorD);
+            var lerped = GradientPair.Lerp(x, y, .1f);
+            Assert.AreEqual(Color.Lerp(x.a, y.a, .1f),  lerped.a);
+            Assert.AreEqual(Color.Lerp(x.b, y.b, .1f),  lerped.b);
+        }
+
+        [TearDown]
+        public void Cleanup() { }
+    }
+}
+

--- a/Tests/Editor/Unit/Utilities/GradientPairTests.cs.meta
+++ b/Tests/Editor/Unit/Utilities/GradientPairTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a65a19f0694c18b4694e6140bf1acb30
+timeCreated: 1500329146
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Utilities/MaterialUtilsTests.cs
+++ b/Tests/Editor/Unit/Utilities/MaterialUtilsTests.cs
@@ -1,0 +1,70 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using NUnit.Framework;
+using System;
+using UnityEditor.Experimental.EditorVR.Utilities;
+using UnityEditor.Experimental.EditorVR.Tests.TestHelpers;
+
+namespace UnityEditor.Experimental.EditorVR.Tests.Utilities
+{
+    public class MaterialUtilsTests
+    {
+        GameObject go;
+        Renderer renderer;
+        Graphic graphic;
+        Material clone;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            go = new GameObject("renderer object");
+            Shader shader = Shader.Find("Standard");
+
+            renderer = go.AddComponent<MeshRenderer>();
+            renderer.sharedMaterial = new Material(shader);
+            graphic = go.AddComponent<TestImage>();
+            graphic.material = renderer.sharedMaterial;
+        }
+
+        [Test]
+        public void GetMaterialClone_ClonesRendererSharedMaterial()
+        {
+            clone = MaterialUtils.GetMaterialClone(renderer);
+            Assert.AreEqual(renderer.sharedMaterial, clone);
+            ObjectUtils.Destroy(clone);
+        }
+
+        [Test]
+        public void GetMaterialClone_ClonesGraphicMaterial()
+        {
+            clone = MaterialUtils.GetMaterialClone(graphic);
+            Assert.AreEqual(graphic.material, clone);
+            ObjectUtils.Destroy(clone);
+        }
+
+        // normally you can directly assert equality on Colors, but 
+        // creating them based on the float coming from this results in mismatches due to rounding
+        private void AssertColorsEqual(Color expected, Color actual)
+        {
+            Assert.AreEqual(Math.Round(expected.r, 3), Math.Round(actual.r, 3));
+            Assert.AreEqual(Math.Round(expected.g, 3), Math.Round(actual.g, 3));
+            Assert.AreEqual(Math.Round(expected.b, 3), Math.Round(actual.b, 3));
+            Assert.AreEqual(Math.Round(expected.a, 3), Math.Round(actual.a, 3));
+        }
+
+        [TestCase("#000000", 0f, 0f, 0f, 1f)]                      // rgb: 0, 0, 0
+        [TestCase("#002244", 0f, 0.133f, 0.267f, 1f)]              // rgb: 136, 221, 102
+        [TestCase("#4488BBBB", 0.267f, 0.533f, 0.733f, 0.733f)]    // rgb: 68, 136, 187
+        [TestCase("#FFFFFF", 1f, 1f, 1f, 1f)]                      // rgb: 255,255,255 
+        public void HextoColor_DoesValidConversion(string hex, float r, float g, float b, float a)
+        {
+            Color expected = new Color(r, g, b, a);
+            Color output = MaterialUtils.HexToColor(hex);
+            AssertColorsEqual(expected, output);
+        }
+
+        [TearDown]
+        public void Cleanup() {}
+    }
+
+}

--- a/Tests/Editor/Unit/Utilities/MaterialUtilsTests.cs
+++ b/Tests/Editor/Unit/Utilities/MaterialUtilsTests.cs
@@ -1,7 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using NUnit.Framework;
-using System;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEditor.Experimental.EditorVR.Tests.TestHelpers;
 
@@ -46,10 +45,11 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Utilities
         // creating them based on the float coming from this results in mismatches due to rounding
         private void AssertColorsEqual(Color expected, Color actual)
         {
-            Assert.AreEqual(Math.Round(expected.r, 3), Math.Round(actual.r, 3));
-            Assert.AreEqual(Math.Round(expected.g, 3), Math.Round(actual.g, 3));
-            Assert.AreEqual(Math.Round(expected.b, 3), Math.Round(actual.b, 3));
-            Assert.AreEqual(Math.Round(expected.a, 3), Math.Round(actual.a, 3));
+            float tolerance = 0.334f;
+            Assert.That(actual.r, Is.EqualTo(expected.r).Within(tolerance));
+            Assert.That(actual.g, Is.EqualTo(expected.g).Within(tolerance));
+            Assert.That(actual.b, Is.EqualTo(expected.b).Within(tolerance));
+            Assert.That(actual.a, Is.EqualTo(expected.a).Within(tolerance));
         }
 
         [TestCase("#000000", 0f, 0f, 0f, 1f)]                      // rgb: 0, 0, 0
@@ -58,9 +58,7 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Utilities
         [TestCase("#FFFFFF", 1f, 1f, 1f, 1f)]                      // rgb: 255,255,255 
         public void HextoColor_DoesValidConversion(string hex, float r, float g, float b, float a)
         {
-            Color expected = new Color(r, g, b, a);
-            Color output = MaterialUtils.HexToColor(hex);
-            AssertColorsEqual(expected, output);
+            AssertColorsEqual(new Color(r, g, b, a), MaterialUtils.HexToColor(hex));
         }
 
         [TearDown]

--- a/Tests/Editor/Unit/Utilities/MaterialUtilsTests.cs.meta
+++ b/Tests/Editor/Unit/Utilities/MaterialUtilsTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c71d550c95f034e499c511a5e57017d4
+timeCreated: 1500329146
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Utilities/MathUtilsExtTests.cs
+++ b/Tests/Editor/Unit/Utilities/MathUtilsExtTests.cs
@@ -1,0 +1,48 @@
+﻿using UnityEngine;
+using NUnit.Framework;
+using UnityEditor.Experimental.EditorVR.Utilities;
+
+namespace UnityEditor.Experimental.EditorVR.Tests.Utilities
+{
+    [TestFixture]
+    public class MathUtilsExtTests
+    {
+        [OneTimeSetUp]
+        public void Setup() {}
+
+        [Test]
+        public void SmoothDamp_DividesSmoothTimeBy3_Float()
+        {
+            var velocity = 1f;
+            var damped = MathUtilsExt.SmoothDamp(2f, 8f, ref velocity, .3f, 10f, .1f);
+            velocity = 1f;
+            var dampedExpected = Mathf.SmoothDamp(2f, 8f, ref velocity, .1f, 10f, .1f);
+
+            Assert.AreEqual(dampedExpected, damped);
+        }
+
+        [Test]
+        public void SmoothDamp_DividesSmoothTimeBy3_Vector3()
+        {
+            var velocity = new Vector3(2, 1, 0);
+            var current = new Vector3(0, 0, 0);
+            var target = new Vector3(2, 4, 8);
+            var damped = MathUtilsExt.SmoothDamp(current, target, ref velocity, .3f, 10f, .1f);
+            velocity = new Vector3(2, 1, 0);
+            var dampedExpected = Vector3.SmoothDamp(current, target, ref velocity, .1f, 10f, .1f);
+
+            Assert.AreEqual(dampedExpected, damped);
+        }
+        
+        [Test]
+        public void ConstrainYawRotation ()
+        {
+            var rotation = new Quaternion(4, 3, 2, 1);
+            var newRotation = MathUtilsExt.ConstrainYawRotation(rotation);
+            Assert.AreEqual(new Quaternion(0, rotation.y, 0, rotation.w), newRotation);
+        }
+
+        [TearDown]
+        public void Cleanup() { }
+    }
+}

--- a/Tests/Editor/Unit/Utilities/MathUtilsExtTests.cs.meta
+++ b/Tests/Editor/Unit/Utilities/MathUtilsExtTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5179400e20fc7d24d9cdb3b3aa0c9c42
+timeCreated: 1500329146
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Unit/Utilities/ObjectUtilsTests.cs
+++ b/Tests/Editor/Unit/Utilities/ObjectUtilsTests.cs
@@ -1,0 +1,161 @@
+﻿using UnityEngine;
+using UnityEditor;
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine.TestTools;
+using UnityEditor.Experimental.EditorVR.Utilities;
+
+namespace UnityEditor.Experimental.EditorVR.Tests.Utilities
+{
+    [TestFixture]
+    public class ObjectUtilsTests
+    {
+        GameObject go, parent, other;
+
+        [SetUp]
+        public void BeforeEach()
+        {
+            go = new GameObject("object utils test");
+            parent = new GameObject("parent");
+            parent.transform.position += new Vector3(2, 4, 8);
+            other = new GameObject("other");
+            other.transform.position += new Vector3(-5, 1, 2);
+        }
+
+        [Test]
+        public void Instantiate_OneArg_ClonesActiveAtOrigin()
+        {
+            var clone = ObjectUtils.Instantiate(go);
+            Assert.IsTrue(clone.activeSelf);
+            Assert.AreEqual(new Vector3(0, 0, 0), clone.transform.position);
+        }
+
+        [Test]
+        public void Instantiate_InactiveClone()
+        {
+            var clone = ObjectUtils.Instantiate(go, null, true, true, false);
+            Assert.IsFalse(clone.activeSelf);
+        }
+
+        [Test]
+        public void Instantiate_WithParent_WorldPositionStays()
+        {
+            var clone = ObjectUtils.Instantiate(go, parent.transform);
+            Assert.AreEqual(parent.transform, clone.transform.parent);
+            Assert.AreNotEqual(parent.transform.position, clone.transform.position);
+        }
+
+        [Test]
+        public void Instantiate_WithParent_WorldPositionMoves()
+        {
+            var clone = ObjectUtils.Instantiate(go, parent.transform, false);
+            Assert.AreEqual(parent.transform, clone.transform.parent);
+            Assert.AreEqual(parent.transform.position, clone.transform.position);
+            Assert.AreEqual(parent.transform.rotation, clone.transform.rotation);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Instantiate_SetRunInEditMode(bool expected)
+        {
+            Assert.IsFalse(Application.isPlaying);
+            var clone = ObjectUtils.Instantiate(go, null, true, expected);
+            AssertRunInEditModeSet(clone, expected);
+        }
+
+        [UnityTest]
+        public IEnumerator Destroy_OneArg_DestroysImmediately_InEditMode()
+        {
+            Assert.IsFalse(Application.isPlaying);
+            ObjectUtils.Destroy(other);
+            yield return null;              // skip frame to allow destruction to run
+            Assert.IsTrue(other == null);
+        }
+
+        // here, we could test the other types of calls to Destroy / Instantiate, but that
+        // would require refactor / making some things "internal" instead of private,
+        // as well as figuring out how we want to do mocking / stubs - hard to test coroutines
+
+        [Test]
+        public void CreateGameObjectWithComponent_OneArg_TypeAsGeneric()
+        {
+            var renderer = ObjectUtils.CreateGameObjectWithComponent<MeshRenderer>();
+            // the object name assigned is based on the component's type name
+            var foundObject = GameObject.Find(typeof(MeshRenderer).Name);
+            Assert.IsInstanceOf<MeshRenderer>(renderer);
+            Assert.IsInstanceOf<MeshRenderer>(foundObject.GetComponent<MeshRenderer>());
+        }
+
+        [Test]
+        public void CreateGameObjectWithComponent_SetsParent_WorldPositionStays()
+        {
+            var comp = ObjectUtils.CreateGameObjectWithComponent<MeshRenderer>(parent.transform);
+            Assert.AreEqual(parent.transform, comp.transform.parent);
+            Assert.AreNotEqual(parent.transform.position, comp.transform.position);
+        }
+
+        [Test]
+        public void CreateGameObjectWithComponent_SetsParent_WorldPositionMoves()
+        {
+            var comp = ObjectUtils.CreateGameObjectWithComponent<MeshRenderer>(parent.transform, false);
+            Assert.AreEqual(parent.transform, comp.transform.parent);
+            Assert.AreEqual(parent.transform.position, comp.transform.position);
+        }
+
+        [Test]
+        public void AddComponent_AddsToObject_TypeAsGeneric()
+        {
+            var instance = ObjectUtils.AddComponent<MeshRenderer>(other);
+            var onObject = other.GetComponent<MeshRenderer>();
+            Assert.IsInstanceOf<MeshRenderer>(instance);
+            Assert.AreEqual(instance, onObject);
+            AssertRunInEditModeSet(other, true);
+        }
+
+        [Test]
+        public void AddComponent_AddsToObject_TypeAsArg()
+        {
+            var instance = ObjectUtils.AddComponent(typeof(MeshRenderer), other);
+            var onObject = other.GetComponent<MeshRenderer>();
+            Assert.IsInstanceOf<Component>(instance);
+            Assert.AreEqual((MeshRenderer)instance, onObject);
+            AssertRunInEditModeSet(other, true);
+        }
+
+        [Test]
+        public void GetBounds_WithoutExtents()
+        {
+            var localBounds = new Bounds(other.transform.position, new Vector3(0, 0, 0));
+            var bounds = ObjectUtils.GetBounds(other.transform);
+
+            Assert.AreEqual(localBounds, bounds);
+        }
+
+        [Test]
+        public void GetBounds_Array()
+        {
+            var gameObjectA = new GameObject();
+            gameObjectA.transform.position += new Vector3(-5, -2, 8);
+            var gameObjectB = new GameObject();
+            gameObjectB.transform.position += new Vector3(2, 6, 4);
+            var transforms = new Transform[] { gameObjectA.transform, gameObjectB.transform };
+
+            var bounds = ObjectUtils.GetBounds(transforms);
+            Bounds expected = new Bounds(new Vector3(-1.5f, 2f, 6f), new Vector3(7f, 8f, 4f));
+            Assert.AreEqual(expected, bounds);
+        }
+
+        [TearDown]
+        public void Cleanup() { }
+
+        // this doesn't actually do it recursively yet
+        private void AssertRunInEditModeSet(GameObject go, bool expected)
+        {
+            var MBs = go.GetComponents<MonoBehaviour>();
+            foreach (var mb in MBs)
+            {
+                Assert.AreEqual(expected, mb.runInEditMode);
+            }
+        }
+    }
+}

--- a/Tests/Editor/Unit/Utilities/ObjectUtilsTests.cs
+++ b/Tests/Editor/Unit/Utilities/ObjectUtilsTests.cs
@@ -11,6 +11,7 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Utilities
     public class ObjectUtilsTests
     {
         GameObject go, parent, other;
+        float delta = 0.00000001f;
 
         [SetUp]
         public void BeforeEach()
@@ -142,7 +143,8 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Utilities
 
             var bounds = ObjectUtils.GetBounds(transforms);
             Bounds expected = new Bounds(new Vector3(-1.5f, 2f, 6f), new Vector3(7f, 8f, 4f));
-            Assert.AreEqual(expected, bounds);
+
+            Assert.That(bounds, Is.EqualTo(expected).Within(delta));
         }
 
         [TearDown]

--- a/Tests/Editor/Unit/Utilities/ObjectUtilsTests.cs.meta
+++ b/Tests/Editor/Unit/Utilities/ObjectUtilsTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0909d0d41dcc485479441e0c5063aeb1
+timeCreated: 1500329146
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Test Helpers.meta
+++ b/Tests/Test Helpers.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f9d6a31ffbe20694bb23ed7f8c506aa2
+folderAsset: yes
+timeCreated: 1500335530
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Test Helpers/TestImage.cs
+++ b/Tests/Test Helpers/TestImage.cs
@@ -1,8 +1,7 @@
 ﻿using UnityEngine.UI;
 
-// if you create a custom class in a file that doesn't match the class name,
-// after the tests run Unity will complain that the compiler that imported 
-// "TestImage" isn't available anymore, so they go in their own files
+// this class exists to allow testing of the overload for 
+// MaterialUtils.GetMaterialClone that takes a Graphic-derived class
 namespace UnityEditor.Experimental.EditorVR.Tests.TestHelpers
 {
     public class TestImage : Graphic

--- a/Tests/Test Helpers/TestImage.cs
+++ b/Tests/Test Helpers/TestImage.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine.UI;
+
+// if you create a custom class in a file that doesn't match the class name,
+// after the tests run Unity will complain that the compiler that imported 
+// "TestImage" isn't available anymore, so they go in their own files
+namespace UnityEditor.Experimental.EditorVR.Tests.TestHelpers
+{
+    public class TestImage : Graphic
+    {
+        protected override void OnPopulateMesh(VertexHelper vh) { }
+    }
+}
+

--- a/Tests/Test Helpers/TestImage.cs.meta
+++ b/Tests/Test Helpers/TestImage.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a4635ef6f23cf1f4a96b2a0feecf278b
+timeCreated: 1500335545
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
the beginning of real unit tests for EditorVR

I chose to write tests for the commonly used utilities & extension methods first, not because they're the most likely to break or the most important code (they aren't), but because other code relies on them & their clear definition & small scope are ideal for establishing nice testing patterns.

These are meant to be thorough but not exhaustive - i searched for the number of references to each function in the project & made sure i only wrote tests for things we're using.

I'm already working on the next batch of tests, which will be around more "core" stuff like Contexts, Modules, & initialization.
