### PR TITLE
make test setup possible by eliminating static EVR contructor

### DIFF
--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -99,8 +99,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			EditorPrefs.DeleteKey(k_SerializedPreferences);
 		}
 
-		// code from the previous static contructor moved here to allow for testability
-		void HandleInitialization()
+		// Code from the previous static constructor moved here to allow for testability
+		static void HandleInitialization()
 		{
 			if (!s_IsInitialized)
 			{

--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -35,6 +35,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
 		bool m_HasDeserialized;
 
+		static bool s_IsInitialized;
+
 		static EditorVR s_Instance;
 
 		static HideFlags defaultHideFlags
@@ -97,14 +99,44 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			EditorPrefs.DeleteKey(k_SerializedPreferences);
 		}
 
+		// code from the previous static contructor moved here to allow for testability
+		void HandleInitialization()
+		{
+			if (!s_IsInitialized)
+			{
+				s_IsInitialized = true;
+
+				if (!PlayerSettings.virtualRealitySupported)
+					Debug.Log("<color=orange>EditorVR requires VR support. Please check Virtual Reality Supported in Edit->Project Settings->Player->Other Settings</color>");
+
+#if !ENABLE_OVR_INPUT && !ENABLE_STEAMVR_INPUT && !ENABLE_SIXENSE_INPUT
+				Debug.Log("<color=orange>EditorVR requires at least one partner (e.g. Oculus, Vive) SDK to be installed for input. You can download these from the Asset Store or from the partner's website</color>");
+#endif
+
+				// Add EVR tags and layers if they don't exist
+				var tags = TagManager.GetRequiredTags();
+				var layers = TagManager.GetRequiredLayers();
+
+				foreach (var tag in tags)
+				{
+					TagManager.AddTag(tag);
+				}
+
+				foreach (var layer in layers)
+				{
+					TagManager.AddLayer(layer);
+				}
+			}
+		}
+
 		void Awake()
 		{
 			s_Instance = this; // Used only by PreferencesGUI
 			Nested.evr = this; // Set this once for the convenience of all nested classes
 			m_DefaultTools = defaultTools;
 			SetHideFlags(defaultHideFlags);
-
 			ClearDeveloperConsoleIfNecessary();
+			HandleInitialization();
 
 			m_Interfaces = (Interfaces)AddNestedModule(typeof(Interfaces));
 			AddModule<SerializedPreferencesModule>(); // Added here in case any nested modules have preference serialization
@@ -463,32 +495,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			}
 
 			EditorApplication.DirtyHierarchyWindowSorting(); // Otherwise objects aren't shown/hidden in hierarchy window
-		}
-
-		static EditorVR()
-		{
-			ObjectUtils.hideFlags = defaultHideFlags;
-
-			if (!PlayerSettings.virtualRealitySupported)
-				Debug.Log("<color=orange>EditorVR requires VR support. Please check Virtual Reality Supported in Edit->Project Settings->Player->Other Settings</color>");
-
-#if !ENABLE_OVR_INPUT && !ENABLE_STEAMVR_INPUT && !ENABLE_SIXENSE_INPUT
-			Debug.Log("<color=orange>EditorVR requires at least one partner (e.g. Oculus, Vive) SDK to be installed for input. You can download these from the Asset Store or from the partner's website</color>");
-#endif
-
-			// Add EVR tags and layers if they don't exist
-			var tags = TagManager.GetRequiredTags();
-			var layers = TagManager.GetRequiredLayers();
-
-			foreach (var tag in tags)
-			{
-				TagManager.AddTag(tag);
-			}
-
-			foreach (var layer in layers)
-			{
-				TagManager.AddLayer(layer);
-			}
 		}
 
 		[PreferenceItem("EditorVR")]


### PR DESCRIPTION
move the code from EditorVR's static constructor to inside the Awake block to allow for setup within the context of tests.  

Cleaned up version of what we mobbed earlier - decided a separate function to keep all that block in was cleaner.