### PR TITLE
Grid view item count updates when the asset grid is resized

### DIFF
--- a/Scripts/ListView/ListViewControllerBase.cs
+++ b/Scripts/ListView/ListViewControllerBase.cs
@@ -68,7 +68,7 @@ namespace ListView
 
 		protected abstract float listHeight { get; }
 
-		public Vector3 size
+		public virtual Vector3 size
 		{
 			set
 			{

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
@@ -62,16 +62,16 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			}
 		}
 
-	    public override Vector3 size
-	    {
-	        set
-	        {
-	            base.size = value; 
-	            m_LastHiddenItemOffset = Mathf.Infinity;
-	        }
-	    }
+		public override Vector3 size
+		{
+			set
+			{
+				base.size = value; 
+				m_LastHiddenItemOffset = Mathf.Infinity;
+			}
+		}
 
-	    protected override void Setup()
+		protected override void Setup()
 		{
 			base.Setup();
 

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
@@ -62,7 +62,16 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 			}
 		}
 
-		protected override void Setup()
+	    public override Vector3 size
+	    {
+	        set
+	        {
+	            base.size = value; 
+	            m_LastHiddenItemOffset = Mathf.Infinity;
+	        }
+	    }
+
+	    protected override void Setup()
 		{
 			base.Setup();
 


### PR DESCRIPTION
### Purpose of this PR
Fixes #247 
https://github.com/Unity-Technologies/EditorVR/issues/247
Size setter for list view controller base is now virtual, which lets the asset grid view invalidate its hidden item index when that value is set.

### Testing status
Tested in the project view workspace in the adventure scene demo - 5.6 mainline editorVR

### Technical risk

Very Low: One function was made virtual but was only overriden in AssetGridViewController.

### Comments to reviewers
