### PR TITLE
Added headCenteredOrigin for camera tracking

### DIFF
--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -132,9 +132,14 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			m_Camera.nearClipPlane = 0.01f;
 			m_Camera.farClipPlane = 1000f;
 
-			// Generally, we want to be at a standing height, so default to that
 			Vector3 position = m_CameraRig.position;
-			position.y = HeadHeight;
+
+            // For stationary tracking, we want to simulate being at a head height.  Roomscale manages height automatically
+            if (VRDevice.GetTrackingSpaceType() == TrackingSpaceType.Stationary)
+            {
+                position.y = HeadHeight;
+            }
+
 			m_CameraRig.position = position;
 			m_CameraRig.rotation = Quaternion.identity;
 

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -94,6 +94,14 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			}
 		}
 
+		public static Vector3 headCenteredOrigin
+		{
+			get
+			{
+				return VRDevice.GetTrackingSpaceType() == TrackingSpaceType.Stationary ? Vector3.up * HeadHeight : Vector3.zero;
+			}
+		}
+
 		public static event Action viewEnabled;
 		public static event Action viewDisabled;
 		public static event Action<EditorWindow> beforeOnGUI;
@@ -131,16 +139,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 			m_Camera.transform.parent = m_CameraRig;
 			m_Camera.nearClipPlane = 0.01f;
 			m_Camera.farClipPlane = 1000f;
-
-			Vector3 position = m_CameraRig.position;
-
-            // For stationary tracking, we want to simulate being at a head height.  Roomscale manages height automatically
-            if (VRDevice.GetTrackingSpaceType() == TrackingSpaceType.Stationary)
-            {
-                position.y = HeadHeight;
-            }
-
-			m_CameraRig.position = position;
+			m_CameraRig.position = headCenteredOrigin;
 			m_CameraRig.rotation = Quaternion.identity;
 
 			m_ShowDeviceView = EditorPrefs.GetBool(k_ShowDeviceView, false);

--- a/Tools/LocomotionTool/LocomotionTool.cs
+++ b/Tools/LocomotionTool/LocomotionTool.cs
@@ -486,7 +486,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 								{
 									m_AllowScaling = false;
 #if UNITY_EDITORVR
-									cameraRig.position = Vector3.up * VRView.HeadHeight;
+									cameraRig.position = VRView.headCenteredOrigin;
 #endif
 									cameraRig.rotation = Quaternion.identity;
 


### PR DESCRIPTION
### Purpose of this PR
Fixes #228

Added a property to the VRViewer : headCenteredOrigin.  This returns a zero vector in roomscale or a vector at roughly standing height for sitting/stationary tracking.  The player's starting position and position they are reset to in the locomotion tool now use this value.

### Testing status

Tested with Oculus in the adventure scene for stationary.  Tested by @mtschoen-unity with the Vive headset for roomscale.

### Technical risk

Low:  Ultimately this just offsets the head a little bit vertically in an environment where you can locomote yourself up and down extremely easily.  

### Comments to reviewers
