### PR TITLE
Fix inspector workspace

### DIFF
--- a/Workspaces/Base/Workspace.cs
+++ b/Workspaces/Base/Workspace.cs
@@ -14,7 +14,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 	{
 		const float k_MaxFrameSize = 100f; // Because BlendShapes cap at 100, our workspace maxes out at 100m wide
 
-		public static readonly Vector3 DefaultBounds = new Vector3(0.7f, 0.4f, 0.4f);
+		public static readonly Vector3 DefaultBounds = new Vector3(0.7f, 0f, 0.4f);
 		public static readonly Vector3 MinBounds = new Vector3(0.55f, 0f, 0.1f);
 
 		public const float FaceMargin = 0.025f;

--- a/Workspaces/InspectorWorkspace/InspectorWorkspace.cs
+++ b/Workspaces/InspectorWorkspace/InspectorWorkspace.cs
@@ -66,6 +66,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
 			Undo.postprocessModifications += OnPostprocessModifications;
 			Undo.undoRedoPerformed += OnUndoRedo;
+
+			// Propagate initial bounds
+			OnBoundsChanged();
 		}
 
 		void OnUndoRedo()


### PR DESCRIPTION
@amydigiov noticed a regression that slipped through with my menu-hide branch. The change to workspace minbounds caused the size property of the inspector listview to never be set, leaving it with a size of 0. This caused all rows to show up hidden, even when the inspector was populated with data.

The fix is just to kick the bounds at start, like other workspaces that require size to be set at start (Hierarchy, etc.). I also noticed that the default bounds still had a height of 40cm which isn't sensible.