### PR TITLE
Fix for annotation tool bug

### DIFF
--- a/Scripts/Core/EditorVR.Tools.cs
+++ b/Scripts/Core/EditorVR.Tools.cs
@@ -162,6 +162,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 				{
 					usedDevices.UnionWith(actionMapInput.GetCurrentlyUsedDevices());
 					InputUtils.CollectDeviceSlotsFromActionMapInput(actionMapInput, ref deviceSlots);
+
+					actionMapInput.Reset(false);
 				}
 
 				if (usedDevices.Count == 0)
@@ -308,7 +310,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 							return;
 						}
 
-						deviceData.toolData.Pop();
+						var oldTool = deviceData.toolData.Pop();
+						oldTool.input.active = false;
 						topTool = deviceData.toolData.Peek();
 						deviceData.currentTool = topTool.tool;
 
@@ -321,7 +324,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 								var otherTool = otherDeviceData.currentTool;
 								if (otherTool == tool)
 								{
-									otherDeviceData.toolData.Pop();
+									oldTool = otherDeviceData.toolData.Pop();
+									oldTool.input.active = false;
 									var otherToolData = otherDeviceData.toolData.Peek();
 									if (otherToolData != null)
 										otherDeviceData.currentTool = otherToolData.tool;
@@ -335,7 +339,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 								{
 									if (otherTool.GetType() == toolType)
 									{
-										otherDeviceData.toolData.Pop();
+										oldTool = otherDeviceData.toolData.Pop();
+										oldTool.input.active = false;
 										var otherToolData = otherDeviceData.toolData.Peek();
 										if (otherToolData != null)
 										{

--- a/Scripts/Modules/DeviceInputModule.cs
+++ b/Scripts/Modules/DeviceInputModule.cs
@@ -67,7 +67,8 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			var removeList = new List<InputControl>();
 			foreach (var lockedControl in m_LockedControls)
 			{
-				if (Mathf.Approximately(lockedControl.rawValue, lockedControl.provider.GetControlData(lockedControl.index).defaultValue))
+				if (!lockedControl.provider.active || Mathf.Approximately(lockedControl.rawValue,
+					lockedControl.provider.GetControlData(lockedControl.index).defaultValue))
 					removeList.Add(lockedControl);
 				else
 					ConsumeControl(lockedControl);
@@ -76,6 +77,9 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			// Remove separately, since we cannot remove while iterating
 			foreach (var inputControl in removeList)
 			{
+				if (!inputControl.provider.active)
+					ResetControl(inputControl);
+
 				m_LockedControls.Remove(inputControl);
 			}
 
@@ -211,7 +215,11 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 			// another AMI to pick up a wasPressed the next frame, since it's own input would have been cleared. The
 			// control is released when it returns to it's default value
 			m_LockedControls.Add(control);
+			ResetControl(control);
+		}
 
+		void ResetControl(InputControl control)
+		{
 			var ami = control.provider as ActionMapInput;
 			var playerHandleMaps = m_PlayerHandle.maps;
 			for (int i = 0; i < playerHandleMaps.Count; i++)


### PR DESCRIPTION
### Purpose of this PR

Fix a bug where switching to the Annotation Tool via spatial scrolling would cause a null reference exception

### Testing status

Issue can be reproduced by using spatial scrolling to select the annotation tool, releasing the grip trigger first, and then releasing the primary trigger

### Technical risk

High: Changes how input is processed, so we should check other systems. 

### Comments to reviewers

Thankfully, I didn't have to make this fix in the tool.  We just needed to do a little more resetting of ActionMapInputs.