### PR TITLE
fix blink locomotion when changing player scale

### DIFF
--- a/Tools/LocomotionTool/LocomotionTool.cs
+++ b/Tools/LocomotionTool/LocomotionTool.cs
@@ -199,7 +199,12 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 			this.SetUIBlockedForRayOrigin(rayOrigin, true);
 
 			if (DoTwoHandedScaling(consumeControl))
+			{
+				if (m_Preferences.blinkMode)
+					if (DoBlink(consumeControl))
+						return;
 				return;
+			}
 
 			if (DoRotating(consumeControl))
 				return;

--- a/Tools/LocomotionTool/LocomotionTool.cs
+++ b/Tools/LocomotionTool/LocomotionTool.cs
@@ -201,8 +201,8 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 			if (DoTwoHandedScaling(consumeControl))
 			{
 				if (m_Preferences.blinkMode)
-					if (DoBlink(consumeControl))
-						return;
+					if (m_LocomotionInput.blink.isHeld)
+						m_BlinkVisuals.visible = false;
 				return;
 			}
 


### PR DESCRIPTION
fixes #300 

tested that everything else in locomotion still works as expected.  
now, if you release the blink button while in the middle of changing player scale, the blink is cancelled.

I'm _not wild_ about having to do it like this - with the `if(DoThing) return;` pattern, but as far as the scope of this bugfix goes, i think it's the right solution.
Perhaps there is a better way ?  it seems like this pattern in general will lead to more instances of control being consumed in a way that prevents another system from working.