### PR TITLE
Don't spatial-select tools until input is released

### DIFF
--- a/Menus/ToolsMenu/ToolsMenu.cs
+++ b/Menus/ToolsMenu/ToolsMenu.cs
@@ -200,7 +200,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 					m_ToolsMenuUI.HighlightSingleButtonWithoutMenu((int)(buttonCount * normalizedRepeatingPosition) + 1);
 				}
 			}
-			else if (toolslMenuInput.show.wasJustReleased)
+			else if (spatialScrollData != null && !toolslMenuInput.show.isHeld && !toolslMenuInput.select.isHeld)
 			{
 				consumeControl(toolslMenuInput.show);
 				consumeControl(toolslMenuInput.select);

--- a/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
+++ b/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
@@ -141,6 +141,9 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 				eventData.rayOrigin = rayOrigin;
 				eventData.pointerLength = this.GetPointerLength(eventData.rayOrigin);
 
+				var sourceAMI = source.actionMapInput;
+				var select = sourceAMI.select;
+
 				if (source.isValid != null && !source.isValid(source))
 				{
 					var currentRaycast = eventData.pointerCurrentRaycast;
@@ -148,6 +151,9 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 					eventData.pointerCurrentRaycast = currentRaycast;
 					source.hoveredObject = null;
 					HandlePointerExitAndEnter(eventData, null, true); // Send only exit events
+
+					if (select.wasJustReleased)
+						OnSelectReleased(source);
 					continue;
 				}
 
@@ -155,10 +161,8 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
 				var hasObject = source.hasObject;
 				var hasScrollHandler = false;
-				var sourceAMI = source.actionMapInput;
-				sourceAMI.active = hasObject && ShouldActivateInput(eventData, source.currentObject, out hasScrollHandler);
 
-				var select = sourceAMI.select;
+				sourceAMI.active = hasObject && ShouldActivateInput(eventData, source.currentObject, out hasScrollHandler);
 
 				// Proceed only if pointer is interacting with something
 				if (!sourceAMI.active)


### PR DESCRIPTION
The fact that you could switch tools with the trigger held was causing all sorts of chaos.  There are probably clever input system hacks to prevent this issue. ConsumeControl doesn't work in this case because we are messing with actionmapinputs while changing tools. The input fixes I made yesterday are still valid.

Fixes #322.