### PR TITLE
Fix for the menu button being able to be closed

### DIFF
--- a/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.cs
+++ b/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.cs
@@ -519,6 +519,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
 		void OnSecondaryButtonClicked()
 		{
+		    if (!implementsSecondaryButton)
+		    {
+		        return;
+		    }
 			this.RestartCoroutine(ref m_VisibilityCoroutine, AnimateHideAndDestroy());
 			closeButton();
 			ActionButtonHoverExit();

--- a/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.cs
+++ b/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.cs
@@ -519,10 +519,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
 		void OnSecondaryButtonClicked()
 		{
-		    if (!implementsSecondaryButton)
-		    {
-		        return;
-		    }
+			if (!implementsSecondaryButton)
+			{
+				return;
+			}
 			this.RestartCoroutine(ref m_VisibilityCoroutine, AnimateHideAndDestroy());
 			closeButton();
 			ActionButtonHoverExit();


### PR DESCRIPTION
The tool buttons, when having their secondary option disabled, could still have the button toggled if a user was particularly dexterous/determined enough.  There is now a hard check before activating the secondary 'close' feature that prevents the function from going through.