### PR TITLE
Add a setting to EditorVRContext for VR supersampling

### DIFF
--- a/Scripts/Core/Contexts/EditorVRContext.cs
+++ b/Scripts/Core/Contexts/EditorVRContext.cs
@@ -3,12 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
+using UnityEngine.XR;
 
 namespace UnityEditor.Experimental.EditorVR.Core
 {
     [CreateAssetMenu(menuName = "EditorVR/EditorVR Context")]
     class EditorVRContext : ScriptableObject, IEditingContext
     {
+        [SerializeField]
+        float m_RenderScale = 1f;
+
         [SerializeField]
         internal List<MonoScript> m_DefaultToolStack;
 
@@ -18,6 +22,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
         {
             EditorVR.defaultTools = m_DefaultToolStack.Select(ms => ms.GetClass()).ToArray();
             m_Instance = ObjectUtils.CreateGameObjectWithComponent<EditorVR>();
+
+            XRSettings.eyeTextureResolutionScale = m_RenderScale;
         }
 
         public void Dispose()


### PR DESCRIPTION
### Purpose of this PR
Make use of XRSettings.eyeTextureResolutionScale which was added in 2017.2

### Testing status
Tested in an empty scene and in Polygon Adventure scene. Performance is better when values are < 0, and worse when > 0. Text is much more readable at 2x.

### Technical risk
Low - Just sets a property based on a serialized value

### Comments to reviewers
One downside here is that the setting will be tracked by version control. We could make this into a preference, but I didn't think it would be something you change very often.