### PR TITLE
Making sure the vive proxy is hidden when steam is not enabled

### DIFF
--- a/Scripts/Proxies/Vive/ViveProxy.cs
+++ b/Scripts/Proxies/Vive/ViveProxy.cs
@@ -44,11 +44,6 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
                     placementOverride.tooltip.placements = placementOverride.placements;
                 }
             }
-
-#if !ENABLE_STEAMVR_INPUT
-            hidden = true;
-            enabled = false;
-#endif
         }
 
         static void PostAnimate(Affordance[] affordances, AffordanceDefinition[] affordanceDefinitions, Dictionary<Transform, ProxyAnimator.TransformInfo> transformInfos, ActionMapInput input)
@@ -86,18 +81,17 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
             }
         }
 
-#if ENABLE_STEAMVR_INPUT
         protected override IEnumerator Start()
         {
             yield return base.Start();
 
+            // No oculus proxy uses postAnimate
             if (!m_IsOculus)
             {
                 m_LeftHand.GetComponent<ProxyAnimator>().postAnimate += PostAnimate;
                 m_RightHand.GetComponent<ProxyAnimator>().postAnimate += PostAnimate;
             }
         }
-#endif
     }
 }
 #endif

--- a/Scripts/Proxies/Vive/ViveProxy.cs
+++ b/Scripts/Proxies/Vive/ViveProxy.cs
@@ -46,6 +46,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
             }
 
 #if !ENABLE_STEAMVR_INPUT
+            hidden = true;
             enabled = false;
 #endif
         }


### PR DESCRIPTION
### Purpose of this PR

We were seeing 'ghost controllers' behind the player while testing.  This was caused by the vive-touch gameobjects being created, but the vive-proxy script was then disabled before it could get a 'hidden' command.

This PR fixes the issue by sending the 'hidden' command to the proxy when the SDK check would disable it.

### Testing status

Tested in the adventure demo scene in Oculus and Vive modes, and with all combinations of SDKs present or missing.

### Technical risk

Low: Just hides disabled objects

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]