### PR TITLE
fix toolflow ray selection

### DIFF
--- a/Menus/ToolsMenu/Scripts/ToolsMenuUI.cs
+++ b/Menus/ToolsMenu/Scripts/ToolsMenuUI.cs
@@ -183,6 +183,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         public void AddButton(IToolsMenuButton button, Transform buttonTransform)
         {
+            button.interactable = true;
             button.showAllButtons = ShowAllButtons;
             button.hoverExit = ButtonHoverExitPerformed;
             button.maxButtonCount = maxButtonCount;

--- a/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.cs
+++ b/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.cs
@@ -44,23 +44,18 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         Collider[] m_PrimaryButtonColliders;
 
         [SerializeField]
-        [FormerlySerializedAs("m_CloseButton")]
         GradientButton m_CloseButton;
 
         [SerializeField]
-        [FormerlySerializedAs("m_CloseButtonContainerCanvasGroup")]
         CanvasGroup m_CloseButtonContainerCanvasGroup;
 
         [SerializeField]
-        [FormerlySerializedAs("m_CloseInsetMeshRenderer")]
         SkinnedMeshRenderer m_CloseInsetMeshRenderer;
 
         [SerializeField]
-        [FormerlySerializedAs("m_CloseInsetMaskMeshRenderer")]
         SkinnedMeshRenderer m_CloseInsetMaskMeshRenderer;
 
         [SerializeField]
-        [FormerlySerializedAs("m_CloseButtonColliders")]
         Collider[] m_CloseButtonColliders; // disable for the main menu button & solitary primary tool button
 
         [SerializeField]

--- a/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.prefab
+++ b/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.prefab
@@ -863,6 +863,7 @@ MonoBehaviour:
   m_IconContainer: {fileID: 4000012079080268}
   m_ContentContainer: {fileID: 4000012079080268}
   m_CanvasGroup: {fileID: 225000012815828682}
+  m_Text: {fileID: 114107835723089898}
   m_Icon: {fileID: 114000012344975988}
   m_AlternateIconSprite: {fileID: 0}
   m_NormalContentColor: {r: 1, g: 1, b: 1, a: 1}
@@ -983,6 +984,7 @@ MonoBehaviour:
   m_IconContainer: {fileID: 4000011872301252}
   m_ContentContainer: {fileID: 4000011872301252}
   m_CanvasGroup: {fileID: 225000010727404378}
+  m_Text: {fileID: 114809216055667092}
   m_Icon: {fileID: 114000011650556854}
   m_AlternateIconSprite: {fileID: 0}
   m_NormalContentColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.prefab
+++ b/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.prefab
@@ -851,8 +851,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c14051f25ea615549aeb702ebe3005d8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_NormalGradientPair:
     a: {r: 0.101960786, g: 0.101960786, b: 0.101960786, a: 1}
     b: {r: 0.7176471, g: 0.10980392, b: 0.10980392, a: 1}
@@ -863,7 +863,6 @@ MonoBehaviour:
   m_IconContainer: {fileID: 4000012079080268}
   m_ContentContainer: {fileID: 4000012079080268}
   m_CanvasGroup: {fileID: 225000012815828682}
-  m_Text: {fileID: 114107835723089898}
   m_Icon: {fileID: 114000012344975988}
   m_AlternateIconSprite: {fileID: 0}
   m_NormalContentColor: {r: 1, g: 1, b: 1, a: 1}
@@ -887,8 +886,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d327b5d520391fe4da32c92a940cfbfa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_GradientButton: {fileID: 114000014181189902}
   m_IconContainer: {fileID: 4000011872301252}
   m_PrimaryUIContentContainer: {fileID: 4181584002966386}
@@ -918,8 +917,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 2100000, guid: dd79a285dde86924793e5a909ca783e0, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -945,8 +944,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 2100000, guid: dd79a285dde86924793e5a909ca783e0, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -972,8 +971,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c14051f25ea615549aeb702ebe3005d8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_NormalGradientPair:
     a: {r: 0, g: 0, b: 0, a: 0}
     b: {r: 0, g: 0, b: 0, a: 0}
@@ -984,7 +983,6 @@ MonoBehaviour:
   m_IconContainer: {fileID: 4000011872301252}
   m_ContentContainer: {fileID: 4000011872301252}
   m_CanvasGroup: {fileID: 225000010727404378}
-  m_Text: {fileID: 114809216055667092}
   m_Icon: {fileID: 114000011650556854}
   m_AlternateIconSprite: {fileID: 0}
   m_NormalContentColor: {r: 1, g: 1, b: 1, a: 1}
@@ -993,7 +991,7 @@ MonoBehaviour:
   m_HighlightItems:
   - {fileID: 114000011650556854}
   - {fileID: 0}
-  m_Interactable: 0
+  m_Interactable: 1
   m_IconHighlightedLocalZOffset: -0.0155
   m_BeginHighlightDuration: 0.25
   m_EndHighlightDuration: 0.167
@@ -1009,8 +1007,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1453722849, guid: 89f0137620f6af44b9ba852b4190e64e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -1121,8 +1119,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1453722849, guid: 89f0137620f6af44b9ba852b4190e64e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0


### PR DESCRIPTION
the gradient buttons were non-interactable in the prefab, and when creating a new button we did not set interactable to default to true.   This changes both of those things, so that a gradient button is interactable until it's disabled.