### PR TITLE
fix project view scrollback when there is only one row

### DIFF
--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
@@ -50,7 +50,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                 if (m_NumPerRow == 0)
                     return 0;
 
-                return Mathf.CeilToInt(m_Data.Count / m_NumPerRow) * itemSize.z;
+                var numRows = Mathf.CeilToInt(m_Data.Count / m_NumPerRow);
+                return Mathf.Clamp(numRows, 1, Int32.MaxValue) * itemSize.z;
             }
         }
 
@@ -110,6 +111,11 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
                 if (m_Data.Count % m_NumPerRow == 0)
                     m_ScrollReturn += itemSize.z;
+            }
+            // if we only have one row, snap back as soon as that row would be hidden
+            else if (listHeight == itemSize.z && -m_ScrollOffset > 0)
+            {
+                m_ScrollReturn = itemSize.z / 2;
             }
         }
 


### PR DESCRIPTION
there were two problems:

`listHeight` would be 0 when there were less items than items per row.  this doesn't seem like how `Mathf.CielToInt` should work, but it does.  Now it's clamped to multiply by a minimum of one row.

we were scrolling back once we the negative scroll offset was greater than or equal to the list height, but the first row leaves the screen when scroll offset is < 0.   

i tried having the scroll back point adjust itself based on these scenarios, but those implementations didn't prove as immediately clean as just handling it as a separate case.