### PR TITLE
Miniworld entrance/exit haptic pulse

### DIFF
--- a/Workspaces/Base/Workspace.cs
+++ b/Workspaces/Base/Workspace.cs
@@ -51,6 +51,9 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         protected Vector3? m_CustomStartingBounds;
 
+        protected Transform m_LeftRayOrigin;
+        protected Transform m_RightRayOrigin;
+
         public Vector3 minBounds
         {
             get { return m_MinBounds; }
@@ -132,8 +135,28 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         public ActionMap actionMap { get { return m_ActionMap; } }
         public bool ignoreLocking { get { return false; } }
 
-        public Transform leftRayOrigin { protected get; set; }
-        public Transform rightRayOrigin { protected get; set; }
+        public Transform leftRayOrigin
+        {
+            protected get { return m_LeftRayOrigin; }
+            set
+            {
+                m_LeftRayOrigin = value;
+                leftNode = this.RequestNodeFromRayOrigin(m_LeftRayOrigin);
+            }
+        }
+
+        public Transform rightRayOrigin
+        {
+            protected get { return m_RightRayOrigin; }
+            set
+            {
+                m_RightRayOrigin = value;
+                rightNode = this.RequestNodeFromRayOrigin(m_RightRayOrigin);
+            }
+        }
+
+        protected Node leftNode { get; set; }
+        protected Node rightNode { get; set; }
 
         public virtual void Setup()
         {

--- a/Workspaces/MiniWorldWorkspace/MiniWorldWorkspace.cs.meta
+++ b/Workspaces/MiniWorldWorkspace/MiniWorldWorkspace.cs.meta
@@ -1,8 +1,9 @@
 fileFormatVersion: 2
 guid: aab2ab33b5d370b4889c8004fceb7843
-timeCreated: 1497580319
+timeCreated: 1510825161
 licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences:
   - m_BasePrefab: {fileID: 1000011022840156, guid: 3a2153f70c365c540a3703c4cf22bc45,
@@ -14,8 +15,6 @@ MonoImporter:
       type: 2}
   - m_ResizePulse: {fileID: 11400000, guid: daa1fd8c3e222aa4db108e0a2b0f7a7d, type: 2}
   - m_MovePulse: {fileID: 11400000, guid: 83427d10dc20237408e0246b4b672682, type: 2}
-  - m_FrameHoverPulse: {fileID: 11400000, guid: 7eda595fb79c2124fb4ea55f6253a847,
-      type: 2}
   - m_ContentPrefab: {fileID: 1000012496997414, guid: 1c661791d5dcbf640809b4e15a35395d,
       type: 2}
   - m_RecenterUIPrefab: {fileID: 1000011166056430, guid: 5a75f0f2ee760e74da2620e87db7cdd5,
@@ -26,6 +25,7 @@ MonoImporter:
       type: 2}
   - m_ZoomSliderPrefab: {fileID: 1000011177834630, guid: 41f89a1e8d8d49f4f861f7cb581c1227,
       type: 2}
+  - m_EnterExitPulse: {fileID: 11400000, guid: 75933c4822b17d4408332fdb3a353435, type: 2}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/Workspaces/MiniWorldWorkspace/MiniworldEnterExitPulse.asset
+++ b/Workspaces/MiniWorldWorkspace/MiniworldEnterExitPulse.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1efd705dfe960584581b3390e04777f1, type: 3}
+  m_Name: MiniworldEnterExitPulse
+  m_EditorClassIdentifier: 
+  m_Duration: 0.5
+  m_Intensity: 0.4
+  m_FadeIn: 1
+  m_FadeOut: 1

--- a/Workspaces/MiniWorldWorkspace/MiniworldEnterExitPulse.asset
+++ b/Workspaces/MiniWorldWorkspace/MiniworldEnterExitPulse.asset
@@ -11,7 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1efd705dfe960584581b3390e04777f1, type: 3}
   m_Name: MiniworldEnterExitPulse
   m_EditorClassIdentifier: 
-  m_Duration: 0.5
-  m_Intensity: 0.4
+  m_Duration: 0.125
+  m_Intensity: 0.25
   m_FadeIn: 1
   m_FadeOut: 1

--- a/Workspaces/MiniWorldWorkspace/MiniworldEnterExitPulse.asset.meta
+++ b/Workspaces/MiniWorldWorkspace/MiniworldEnterExitPulse.asset.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 75933c4822b17d4408332fdb3a353435
+timeCreated: 1496975270
+licenseType: Pro
+NativeFormatImporter:
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
Perform a haptic pulse when a rayOrigin/node enters/exits the MiniWorld.  This adds a means of informing the user of such a condition.

### Testing status
Tested in an empty scene, with a single, then multiple Miniworld workspaces.  All worked as expected.

### Technical risk
Low.  The most invasive change would be the addition of the node cacheing in Workspace, when the left & right rayOrigins are set.  This allows us to skip constant RequestNodeFromRayOrigin calls, when a node is needed (pulse haptics).

### Comments to reviewers
Nothing complex here.  Just a simple haptic pulse performed in the manner described above.