### PR TITLE
snapping settings "back" tooltip

### DIFF
--- a/Scripts/Modules/SnappingModule/Prefabs/MenuFaceSnapping.prefab
+++ b/Scripts/Modules/SnappingModule/Prefabs/MenuFaceSnapping.prefab
@@ -2229,7 +2229,6 @@ MonoBehaviour:
   m_TooltipSource: {fileID: 224381481136393154}
   m_TooltipTarget: {fileID: 224314858768579366}
   m_TooltipAlignment: 1
-  m_Button: {fileID: 114000013313040984}
 --- !u!114 &114243426776915280
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -4529,7 +4528,7 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1156207802407454}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -4538,7 +4537,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 253}
+  m_AnchoredPosition: {x: 0, y: 304.8767}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224381481136393154

--- a/Scripts/Modules/SnappingModule/Prefabs/MenuFaceSnapping.prefab
+++ b/Scripts/Modules/SnappingModule/Prefabs/MenuFaceSnapping.prefab
@@ -4537,7 +4537,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 304.8767}
+  m_AnchoredPosition: {x: 0, y: 280.1}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224381481136393154

--- a/Scripts/Modules/SnappingModule/Prefabs/MenuFaceSnapping.prefab
+++ b/Scripts/Modules/SnappingModule/Prefabs/MenuFaceSnapping.prefab
@@ -279,6 +279,7 @@ GameObject:
   - component: {fileID: 222000011837747738}
   - component: {fileID: 114000011539206294}
   - component: {fileID: 114000013313040984}
+  - component: {fileID: 114056734150045564}
   m_Layer: 5
   m_Name: BackButton
   m_TagString: Untagged
@@ -828,6 +829,36 @@ GameObject:
   - component: {fileID: 114768966837101286}
   m_Layer: 5
   m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1156207802407454
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224314858768579366}
+  m_Layer: 5
+  m_Name: TooltipTarget
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1319864966309284
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224381481136393154}
+  m_Layer: 5
+  m_Name: TooltipSource
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2183,6 +2214,22 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114056734150045564
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011386972348}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b54766fd77d29cd4990abe24e9c95399, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TooltipText: Return To Settings
+  m_TooltipSource: {fileID: 224381481136393154}
+  m_TooltipTarget: {fileID: 224314858768579366}
+  m_TooltipAlignment: 1
+  m_Button: {fileID: 114000013313040984}
 --- !u!114 &114243426776915280
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -4172,6 +4219,7 @@ RectTransform:
   m_Children:
   - {fileID: 224000014096748992}
   - {fileID: 224000012196546780}
+  - {fileID: 224314858768579366}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4408,6 +4456,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 224000012874297666}
+  - {fileID: 224381481136393154}
   m_Father: {fileID: 224000013140039042}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4474,6 +4523,42 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!224 &224314858768579366
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1156207802407454}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224000013140039042}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 253}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224381481136393154
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1319864966309284}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224000014096748992}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 15}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!225 &225000010337817060
 CanvasGroup:
   m_ObjectHideFlags: 1

--- a/Scripts/UI/TooltipData.cs
+++ b/Scripts/UI/TooltipData.cs
@@ -1,0 +1,44 @@
+#if UNITY_EDITOR
+using UnityEngine;
+
+namespace UnityEditor.Experimental.EditorVR.UI
+{
+    /// <summary>
+    /// Place on an object that recieves UI events to set a tooltip on it
+    /// </summary>
+    class TooltipData : MonoBehaviour, ITooltip, ITooltipPlacement
+    {
+        [SerializeField]
+        string m_TooltipText;
+        public string tooltipText
+        {
+            get { return m_TooltipText; }
+            protected set { m_TooltipText = value; }
+        }
+
+        [SerializeField]
+        Transform m_TooltipSource;
+        public Transform tooltipSource
+        {
+            get { return m_TooltipSource; }
+            protected set { m_TooltipSource = value; }
+        }
+
+        [SerializeField]
+        Transform m_TooltipTarget;
+        public Transform tooltipTarget
+        {
+            get { return m_TooltipTarget; }
+            protected set { m_TooltipTarget = value; }
+        }
+
+        [SerializeField]
+        TextAlignment m_TooltipAlignment;
+        public TextAlignment tooltipAlignment
+        {
+            get { return m_TooltipAlignment; }
+            protected set { m_TooltipAlignment = value; }
+        }
+    }
+}
+#endif

--- a/Scripts/UI/TooltipData.cs
+++ b/Scripts/UI/TooltipData.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityEditor.Experimental.EditorVR.UI
 {
     /// <summary>
-    /// Place on an object that recieves UI events to set a tooltip on it
+    /// Place on an object that receives UI events to set a tooltip on it
     /// </summary>
     class TooltipData : MonoBehaviour, ITooltip, ITooltipPlacement
     {

--- a/Scripts/UI/TooltipData.cs.meta
+++ b/Scripts/UI/TooltipData.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: b54766fd77d29cd4990abe24e9c95399
+timeCreated: 1510864622
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds a `TooltipData` component class for easily adding tooltips to existing objects, and uses that component to add a tooltip to the snapping menu back button. 

i didn't see a clear standard for positioning of tooltips, so i just set it to something that looked good to me.  if there's a standard, i'd like to make it follow that.   for instance, i see with the main menu tooltip that it's quite a distance from the actual button, but that felt awkward for the top of the main menu.
![snapsettingstooltip](https://user-images.githubusercontent.com/14057748/32917314-a1d7f7f2-cad3-11e7-9cfe-8d02576cfd8b.PNG)
