### PR TITLE
Improvements/andrewm/ui animate tooltip positions

### DIFF
--- a/Scripts/Modules/TooltipModule/TooltipModule.cs
+++ b/Scripts/Modules/TooltipModule/TooltipModule.cs
@@ -14,6 +14,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         const float k_UVScale = 100f;
         const float k_UVScrollSpeed = 1.5f;
         const float k_Offset = 0.05f;
+        const float k_TextOrientationWeight = 0.1f;
 
         const int k_PoolInitialCapacity = 16;
 
@@ -35,6 +36,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             public float duration;
             public Action becameVisible;
             public ITooltipPlacement placement;
+            public float orientationWeight;
 
             public Transform GetTooltipTarget(ITooltip tooltip)
             {
@@ -90,16 +92,15 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                         MathUtilsExt.SetTransformOffset(target, tooltipTransform, Vector3.zero, Quaternion.identity);
                         tooltipTransform.localScale = Vector3.zero;
 
-                        var hasLine = placement != null;
-                        tooltipUI.dottedLine.gameObject.SetActive(hasLine);
+                        tooltipUI.dottedLine.gameObject.SetActive(true);
                         foreach (var sphere in tooltipUI.spheres)
                         {
-                            sphere.gameObject.SetActive(hasLine);
+                            sphere.gameObject.SetActive(true);
                         }
                     }
 
                     var lerp = Mathf.Clamp01((hoverTime - k_Delay) / k_TransitionDuration);
-                    UpdateVisuals(tooltip, tooltipUI, placement, target, lerp);
+                    UpdateVisuals(tooltip, tooltipData, lerp);
                 }
 
                 if (!IsValidTooltip(tooltip))
@@ -136,8 +137,13 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             return tooltipUI;
         }
 
-        void UpdateVisuals(ITooltip tooltip, TooltipUI tooltipUI, ITooltipPlacement placement, Transform target, float lerp)
+        void UpdateVisuals(ITooltip tooltip, TooltipData tooltipData, float lerp)
         {
+            var target = tooltipData.GetTooltipTarget(tooltip);
+            var tooltipUI = tooltipData.tooltipUI;
+            var placement = tooltipData.placement;
+            var orientationWeight = tooltipData.orientationWeight;
+
             var tooltipTransform = tooltipUI.transform;
 
             lerp = MathUtilsExt.SmoothInOutLerpFloat(lerp); // shape the lerp for better presentation
@@ -172,20 +178,18 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 offset = Vector3.back * k_Offset * this.GetViewerScale();
 
             var rotationOffset = Quaternion.identity;
-            var cameraForward = CameraUtils.GetMainCamera().transform.forward;
-            if (Vector3.Dot(cameraForward, target.forward) < 0)
+            var camTransform = CameraUtils.GetMainCamera().transform;
+            if (Vector3.Dot(camTransform.forward, target.forward) < 0)
                 rotationOffset *= k_FlipYRotation;
 
-            var upDot = Vector3.Dot(Vector3.up, target.up);
-            if (Mathf.Abs(Vector3.Dot(Vector3.forward, target.up)) > Mathf.Abs(upDot))
+            if ((Vector3.Dot(camTransform.up, target.up) + orientationWeight) < 0)
             {
-                if (Vector3.Dot(cameraForward, target.up) < 0)
-                    rotationOffset *= k_FlipZRotation;
+                rotationOffset *= k_FlipZRotation;
+                tooltipData.orientationWeight = -k_TextOrientationWeight;
             }
             else
             {
-                if (upDot < 0)
-                    rotationOffset *= k_FlipZRotation;
+                tooltipData.orientationWeight = k_TextOrientationWeight;
             }
 
             MathUtilsExt.SetTransformOffset(target, tooltipTransform, offset * lerp, rotationOffset);
@@ -298,7 +302,8 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 persistent = persistent,
                 duration = duration,
                 becameVisible = becameVisible,
-                placement = placement ?? tooltip as ITooltipPlacement
+                placement = placement ?? tooltip as ITooltipPlacement,
+                orientationWeight = 0.0f,
             };
         }
 
@@ -324,17 +329,14 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
         IEnumerator AnimateHide(ITooltip tooltip, TooltipData data)
         {
-            var placement = data.placement;
             var target = data.GetTooltipTarget(tooltip);
-            var tooltipUI = data.tooltipUI;
             var startTime = Time.realtimeSinceStartup;
             while (Time.realtimeSinceStartup - startTime < k_TransitionDuration)
             {
                 if (!target)
                     break;
 
-                UpdateVisuals(tooltip, tooltipUI, placement, target,
-                    1 - (Time.realtimeSinceStartup - startTime) / k_TransitionDuration);
+                UpdateVisuals(tooltip, data, 1 - (Time.realtimeSinceStartup - startTime) / k_TransitionDuration);
                 yield return null;
             }
 

--- a/Scripts/Modules/TooltipModule/TooltipModule.cs
+++ b/Scripts/Modules/TooltipModule/TooltipModule.cs
@@ -159,7 +159,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             if (Vector3.Dot(camTransform.forward, target.forward) < 0)
                 rotationOffset *= k_FlipYRotation;
 
-            if ((Vector3.Dot(camTransform.up, target.up) + orientationWeight) < 0)
+            if (Vector3.Dot(camTransform.up, target.up) + orientationWeight < 0)
             {
                 rotationOffset *= k_FlipZRotation;
                 tooltipData.orientationWeight = -k_TextOrientationWeight;

--- a/Scripts/Proxies/ProxyNode.cs
+++ b/Scripts/Proxies/ProxyNode.cs
@@ -712,7 +712,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
                 m_RequestData[feedbackKey] = data;
             }
 
-            var suppress = false;//data.presentations > request.maxPresentations - 1;
+            var suppress = data.presentations > request.maxPresentations - 1;
             var suppressPresentation = request.suppressPresentation;
             if (suppressPresentation != null)
                 suppress = suppressPresentation();


### PR DESCRIPTION
### Purpose of this PR
https://favro.com/card/c564ede4ed3337f7b17986b6/Uni-31029

Tooltips previously were hard snapping when their positions were changed.  They now smoothly lerp their positions.

Additionally, the current text orientation and position are weighted when trying to determine if these values should be changed.  This solves the problem where looking at a controller at a boundary between two tooltip positions would cause the system to rapidly switch between the two.

### Testing status

Tested in a blank and adventure scene, playing with the menu, looking at hands, shaking all over the place.

### Technical risk

Low, majority of the changes are visual and confined to a single system.

### Comments to reviewers

I had rotation lerping as well previously - the biggest issue there is that the kind of rotation lerp we want isn't a lerp -or- slerp, it's some kind of custom selection that keeps the billboard always facing the player.