### PR TITLE
fix camera serialization by connecting serialized prefs module

### DIFF
--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -133,6 +133,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
             m_Interfaces = (Interfaces)AddNestedModule(typeof(Interfaces));
             AddModule<SerializedPreferencesModule>(); // Added here in case any nested modules have preference serialization
+            AddNestedModule(typeof(SerializedPreferencesModuleConnector));
 
             var nestedClassTypes = ObjectUtils.GetExtensionsOfClass(typeof(Nested));
             foreach (var type in nestedClassTypes)


### PR DESCRIPTION
we weren't firing the event to serialize preferences because the module wasn't connected at the right time.  This just hooks up the module to fix the serialization.