### PR TITLE
Fix hovered affordance tooltips being disconnected from affordances

### DIFF
--- a/Scripts/Proxies/AffordanceTooltip.cs
+++ b/Scripts/Proxies/AffordanceTooltip.cs
@@ -3,13 +3,19 @@ using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Proxies
 {
-    sealed class AffordanceTooltip : MonoBehaviour, ITooltip
+    sealed class AffordanceTooltip : MonoBehaviour, ITooltip, ITooltipPlacement
     {
         [SerializeField]
         string m_TooltipText;
 
         [SerializeField]
         AffordanceTooltipPlacement[] m_Placements;
+
+        FacingDirection m_LastFacingDirection;
+
+        public Transform tooltipTarget { get { return GetPlacement(m_LastFacingDirection).tooltipTarget; } }
+        public Transform tooltipSource { get { return GetPlacement(m_LastFacingDirection).tooltipSource; } }
+        public TextAlignment tooltipAlignment { get { return GetPlacement(m_LastFacingDirection).tooltipAlignment; } }
 
         public string tooltipText
         {
@@ -21,6 +27,8 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 
         public AffordanceTooltipPlacement GetPlacement(FacingDirection direction)
         {
+            m_LastFacingDirection = direction;
+
             foreach (var placement in m_Placements)
             {
                 if ((placement.facingDirection & direction) != 0)


### PR DESCRIPTION
AffordanceTooltip wasn't an ITooltipPlacement. It now keeps track of the last direction that was used to access the placement, and uses this as the hovered placement.