### PR TITLE
Fix SelectionTool SettingsUI prefab button backgrounds

### DIFF
--- a/Tools/SelectionTool/Prefabs/SettingsUI.prefab
+++ b/Tools/SelectionTool/Prefabs/SettingsUI.prefab
@@ -236,7 +236,7 @@ MonoBehaviour:
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 2100000, guid: db3c88ad8f7fe11479d2d3e48c08e6f0, type: 2}
+  m_Material: {fileID: 2100000, guid: 5d56db48b1271b543accea3e82700754, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_OnCullStateChanged:
@@ -413,7 +413,7 @@ MonoBehaviour:
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 2100000, guid: db3c88ad8f7fe11479d2d3e48c08e6f0, type: 2}
+  m_Material: {fileID: 2100000, guid: 5d56db48b1271b543accea3e82700754, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_OnCullStateChanged:


### PR DESCRIPTION
Set proper SubMenuUIButton materials on SelectionTool SettingsUI prefab backgrounds.  The background objects weren't reflecting the intended background visual representation, nor the proper gradients.