### PR TITLE
Bugfixes/andrewm/blink height

### DIFF
--- a/Tools/LocomotionTool/LocomotionTool.cs
+++ b/Tools/LocomotionTool/LocomotionTool.cs
@@ -769,7 +769,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
             var offset = cameraRig.position - CameraUtils.GetMainCamera().transform.position;
             offset.y = 0;
-            offset += VRView.HeadHeight * Vector3.up * this.GetViewerScale();
+            offset += VRView.headCenteredOrigin * this.GetViewerScale();
 
             targetPosition += offset;
             const float kTargetDuration = 0.05f;


### PR DESCRIPTION
### Purpose of this PR
Fixes #344 
Previously, when using the blink locomotion tool with a roomscale device like the Vive, the 'virtual' headheight would be added in addition to the player's natural offset.

We now instead use the headcenteredorigin, which prevents expression of this double-offset when a roomscale device is used.

### Testing status

Tested in the adventure scene with an HTC Vive and Oculus Rift and the blink tool. (Roomscale and desktop)

### Technical risk

Low, just changing a vector value.

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]