### PR TITLE
Prevent the secondary AnnotationTool hand from consuming the left stick input

### DIFF
--- a/Tools/AnnotationTool/AnnotationTool.cs
+++ b/Tools/AnnotationTool/AnnotationTool.cs
@@ -751,9 +751,6 @@ namespace UnityEditor.Experimental.EditorVR.Tools
                                 Undo.PerformUndo();
                         }
                     }
-
-                    consumeControl(annotationInput.changeBrushSize);
-                    consumeControl(annotationInput.vertical);
                 }
             }
 


### PR DESCRIPTION
### Purpose of this PR
Small change that prevents the secondary(hand with the color-palette) AnnotationTool from consuming the left stick input.  This allows the main menu on the secondary hand to be rotated (as expected), while using the annotation tool on the active(primary) hand.

### Testing status
Tested in scenarios where likely issues could occur.  No issues presented themselves.

### Technical risk
Low, just removal of input consumption on one hand, in the case that the brush is open on the other hand.

### Comments to reviewers
NA