### PR TITLE
Fix bug where player head is selectable

### DIFF
--- a/Scripts/Core/EditorVR.Viewer.cs
+++ b/Scripts/Core/EditorVR.Viewer.cs
@@ -58,7 +58,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             PlayerBody m_PlayerBody;
             float m_OriginalNearClipPlane;
             float m_OriginalFarClipPlane;
-            readonly List<Renderer> m_VRPlayerObjects = new List<Renderer>();
+            readonly List<GameObject> m_VRPlayerObjects = new List<GameObject>();
 
             readonly Preferences m_Preferences = new Preferences();
 
@@ -197,7 +197,12 @@ namespace UnityEditor.Experimental.EditorVR.Core
                 m_PlayerBody = ObjectUtils.Instantiate(evr.m_PlayerModelPrefab, CameraUtils.GetMainCamera().transform, false).GetComponent<PlayerBody>();
                 var renderer = m_PlayerBody.GetComponent<Renderer>();
                 evr.GetModule<SpatialHashModule>().spatialHash.AddObject(renderer, renderer.bounds);
-                renderer.GetComponentsInChildren(true, m_VRPlayerObjects);
+                var playerObjects = m_PlayerBody.GetComponentsInChildren<Renderer>(true);
+                foreach (var playerObject in playerObjects)
+                {
+                    m_VRPlayerObjects.Add(playerObject.gameObject);
+                }
+
                 evr.GetModule<IntersectionModule>().standardIgnoreList.AddRange(m_VRPlayerObjects);
             }
 

--- a/Scripts/Interfaces/FunctionalityInjection/ICheckBounds.cs
+++ b/Scripts/Interfaces/FunctionalityInjection/ICheckBounds.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -13,7 +13,7 @@ namespace UnityEditor.Experimental.EditorVR
 
     public static class ICheckBoundsMethods
     {
-        public delegate bool CheckBoundsDelegate(Bounds bounds, List<GameObject> objects, List<Renderer> ignoreList = null);
+        public delegate bool CheckBoundsDelegate(Bounds bounds, List<GameObject> objects, List<GameObject> ignoreList = null);
 
         public static CheckBoundsDelegate checkBounds { get; set; }
 
@@ -24,7 +24,7 @@ namespace UnityEditor.Experimental.EditorVR
         /// <param name="objects">The list to which intersected Renderers will be added</param>
         /// <param name="ignoreList">(optional) A list of Renderers to ignore</param>
         /// <returns>Whether the bounds intersected any objects</returns>
-        public static bool CheckBounds(this ICheckBounds obj, Bounds bounds, List<GameObject> objects, List<Renderer> ignoreList = null)
+        public static bool CheckBounds(this ICheckBounds obj, Bounds bounds, List<GameObject> objects, List<GameObject> ignoreList = null)
         {
             return checkBounds(bounds, objects, ignoreList);
         }

--- a/Scripts/Interfaces/FunctionalityInjection/ICheckSphere.cs
+++ b/Scripts/Interfaces/FunctionalityInjection/ICheckSphere.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -13,7 +13,7 @@ namespace UnityEditor.Experimental.EditorVR
 
     public static class ICheckSphereMethods
     {
-        public delegate bool CheckSphereDelegate(Vector3 center, float radius, List<GameObject> objects, List<Renderer> ignoreList = null);
+        public delegate bool CheckSphereDelegate(Vector3 center, float radius, List<GameObject> objects, List<GameObject> ignoreList = null);
 
         public static CheckSphereDelegate checkSphere { get; set; }
 
@@ -25,7 +25,7 @@ namespace UnityEditor.Experimental.EditorVR
         /// <param name="objects">The list to which intersected Renderers will be added</param>
         /// <param name="ignoreList">(optional) A list of Renderers to ignore</param>
         /// <returns>Whether the sphere intersected any objects</returns>
-        public static bool CheckSphere(this ICheckBounds obj, Vector3 center, float radius, List<GameObject> objects, List<Renderer> ignoreList = null)
+        public static bool CheckSphere(this ICheckBounds obj, Vector3 center, float radius, List<GameObject> objects, List<GameObject> ignoreList = null)
         {
             return checkSphere(center, radius, objects, ignoreList);
         }

--- a/Scripts/Interfaces/FunctionalityInjection/IGetVRPlayerObjects.cs
+++ b/Scripts/Interfaces/FunctionalityInjection/IGetVRPlayerObjects.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -7,18 +7,19 @@ namespace UnityEditor.Experimental.EditorVR
 {
     /// <summary>
     /// Provides access to the gameobjects that represent the VR player
-    /// </summary>    public interface IGetVRPlayerObjects
+    /// </summary>
+    public interface IGetVRPlayerObjects
     {
     }
 
     public static class IGetVRPlayerObjectsMethods
     {
-        internal static Func<List<Renderer>> getVRPlayerObjects { get; set; }
+        internal static Func<List<GameObject>> getVRPlayerObjects { get; set; }
 
         /// <summary>
         /// Returns objects that are used to represent the VR player
         /// </summary>
-        public static List<Renderer> GetVRPlayerObjects(this IGetVRPlayerObjects obj)
+        public static List<GameObject> GetVRPlayerObjects(this IGetVRPlayerObjects obj)
         {
             return getVRPlayerObjects();
         }

--- a/Scripts/Interfaces/FunctionalityInjection/IRaycast.cs
+++ b/Scripts/Interfaces/FunctionalityInjection/IRaycast.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -13,7 +13,7 @@ namespace UnityEditor.Experimental.EditorVR
 
     public static class IRaycastMethods
     {
-        public delegate bool RaycastDelegate(Ray ray, out RaycastHit hit, out GameObject go, float maxDistance = Mathf.Infinity, List<Renderer> ignoreList = null);
+        public delegate bool RaycastDelegate(Ray ray, out RaycastHit hit, out GameObject go, float maxDistance = Mathf.Infinity, List<GameObject> ignoreList = null);
 
         public static RaycastDelegate raycast { get; set; }
 
@@ -26,7 +26,7 @@ namespace UnityEditor.Experimental.EditorVR
         /// <param name="maxDistance">The maximum distance of the raycast</param>
         /// <param name="ignoreList">(optional) A list of Renderers to ignore</param>
         /// <returns></returns>
-        public static bool Raycast(this IRaycast obj, Ray ray, out RaycastHit hit, out GameObject go, float maxDistance = Mathf.Infinity, List<Renderer> ignoreList = null)
+        public static bool Raycast(this IRaycast obj, Ray ray, out RaycastHit hit, out GameObject go, float maxDistance = Mathf.Infinity, List<GameObject> ignoreList = null)
         {
             return raycast(ray, out hit, out go, maxDistance, ignoreList);
         }

--- a/Scripts/Interfaces/FunctionalityInjection/IStandardIgnoreList.cs
+++ b/Scripts/Interfaces/FunctionalityInjection/IStandardIgnoreList.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -12,7 +12,7 @@ namespace UnityEditor.Experimental.EditorVR
         /// <summary>
         /// List of system objects to ignore for intersection purposes
         /// </summary>
-        List<Renderer> ignoreList { set; }
+        List<GameObject> ignoreList { set; }
     }
 }
 #endif

--- a/Scripts/Modules/IntersectionModule/IntersectionModule.cs
+++ b/Scripts/Modules/IntersectionModule/IntersectionModule.cs
@@ -17,7 +17,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         readonly Dictionary<IntersectionTester, Renderer> m_IntersectedObjects = new Dictionary<IntersectionTester, Renderer>();
         readonly List<IntersectionTester> m_Testers = new List<IntersectionTester>();
         readonly Dictionary<Transform, RayIntersection> m_RaycastGameObjects = new Dictionary<Transform, RayIntersection>(); // Stores which gameobject the proxies' ray origins are pointing at
-        readonly List<Renderer> m_StandardIgnoreList = new List<Renderer>();
+        readonly List<GameObject> m_StandardIgnoreList = new List<GameObject>();
 
         SpatialHash<Renderer> m_SpatialHash;
         MeshCollider m_CollisionTester;
@@ -35,7 +35,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         public List<Renderer> allObjects { get { return m_SpatialHash == null ? null : m_SpatialHash.allObjects; } }
 
         public int intersectedObjectCount { get { return m_IntersectedObjects.Count; } }
-        public List<Renderer> standardIgnoreList { get { return m_StandardIgnoreList; } }
+        public List<GameObject> standardIgnoreList { get { return m_StandardIgnoreList; } }
 
         // Local method use only -- created here to reduce garbage collection
         readonly List<Renderer> m_Intersections = new List<Renderer>();
@@ -221,7 +221,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             m_RaycastGameObjects[rayOrigin] = new RayIntersection { go = go, distance = hit.distance };
         }
 
-        internal bool Raycast(Ray ray, out RaycastHit hit, out GameObject obj, float maxDistance = Mathf.Infinity, List<Renderer> ignoreList = null)
+        internal bool Raycast(Ray ray, out RaycastHit hit, out GameObject obj, float maxDistance = Mathf.Infinity, List<GameObject> ignoreList = null)
         {
             obj = null;
             hit = new RaycastHit();
@@ -233,7 +233,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 for (int i = 0; i < m_Intersections.Count; i++)
                 {
                     var renderer = m_Intersections[i];
-                    if (ignoreList != null && ignoreList.Contains(renderer))
+                    if (ignoreList != null && ignoreList.Contains(renderer.gameObject))
                         continue;
 
                     var transform = renderer.transform;
@@ -261,7 +261,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             return result;
         }
 
-        internal bool CheckBounds(Bounds bounds, List<GameObject> objects, List<Renderer> ignoreList = null)
+        internal bool CheckBounds(Bounds bounds, List<GameObject> objects, List<GameObject> ignoreList = null)
         {
             var result = false;
             m_Intersections.Clear();
@@ -270,7 +270,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 for (var i = 0; i < m_Intersections.Count; i++)
                 {
                     var renderer = m_Intersections[i];
-                    if (ignoreList != null && ignoreList.Contains(renderer))
+                    if (ignoreList != null && ignoreList.Contains(renderer.gameObject))
                         continue;
 
                     var transform = renderer.transform;
@@ -288,7 +288,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             return result;
         }
 
-        internal bool CheckSphere(Vector3 center, float radius, List<GameObject> objects, List<Renderer> ignoreList = null)
+        internal bool CheckSphere(Vector3 center, float radius, List<GameObject> objects, List<GameObject> ignoreList = null)
         {
             var result = false;
             m_Intersections.Clear();
@@ -298,7 +298,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 for (var i = 0; i < m_Intersections.Count; i++)
                 {
                     var renderer = m_Intersections[i];
-                    if (ignoreList != null && ignoreList.Contains(renderer))
+                    if (ignoreList != null && ignoreList.Contains(renderer.gameObject))
                         continue;
 
                     var transform = renderer.transform;

--- a/Scripts/Modules/SelectionModule/SelectionModule.cs
+++ b/Scripts/Modules/SelectionModule/SelectionModule.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +8,8 @@ using Object = UnityEngine.Object;
 
 namespace UnityEditor.Experimental.EditorVR.Modules
 {
-    sealed class SelectionModule : MonoBehaviour, IUsesGameObjectLocking, ISelectionChanged, IControlHaptics, IRayToNode, IContainsVRPlayerCompletely
+    sealed class SelectionModule : MonoBehaviour, IUsesGameObjectLocking, ISelectionChanged, IControlHaptics,
+        IRayToNode, IGetVRPlayerObjects, IContainsVRPlayerCompletely
     {
         [SerializeField]
         HapticPulse m_HoverPulse;
@@ -51,6 +52,9 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             if (hoveredObject != null)
             {
                 if (!hoveredObject.activeInHierarchy)
+                    return false;
+
+                if (this.GetVRPlayerObjects().Contains(hoveredObject))
                     return false;
 
                 if (this.ContainsVRPlayerCompletely(hoveredObject))

--- a/Scripts/Modules/SelectionModule/SelectionModule.cs
+++ b/Scripts/Modules/SelectionModule/SelectionModule.cs
@@ -9,7 +9,7 @@ using Object = UnityEngine.Object;
 namespace UnityEditor.Experimental.EditorVR.Modules
 {
     sealed class SelectionModule : MonoBehaviour, IUsesGameObjectLocking, ISelectionChanged, IControlHaptics,
-        IRayToNode, IGetVRPlayerObjects, IContainsVRPlayerCompletely
+        IRayToNode, IContainsVRPlayerCompletely
     {
         [SerializeField]
         HapticPulse m_HoverPulse;
@@ -52,9 +52,6 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             if (hoveredObject != null)
             {
                 if (!hoveredObject.activeInHierarchy)
-                    return false;
-
-                if (this.GetVRPlayerObjects().Contains(hoveredObject))
                     return false;
 
                 if (this.ContainsVRPlayerCompletely(hoveredObject))

--- a/Scripts/Modules/SnappingModule/SnappingModule.cs
+++ b/Scripts/Modules/SnappingModule/SnappingModule.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using UnityEditor.Experimental.EditorVR;
@@ -243,7 +243,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
         public bool widgetEnabled { get; set; }
 
-        public List<Renderer> ignoreList { private get; set; }
+        public List<GameObject> ignoreList { private get; set; }
 
         public GameObject settingsMenuPrefab { get { return m_SettingsMenuPrefab; } }
 
@@ -370,7 +370,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         public Transform rayOrigin { get { return null; } }
 
         // Local method use only -- created here to reduce garbage collection
-        readonly List<Renderer> m_CombinedIgnoreList = new List<Renderer>();
+        readonly List<GameObject> m_CombinedIgnoreList = new List<GameObject>();
         Transform[] m_SingleTransformArray = new Transform[1];
 
         void Awake()
@@ -745,7 +745,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 var renderers = transforms[i].GetComponentsInChildren<Renderer>();
                 for (var j = 0; j < renderers.Length; j++)
                 {
-                    m_CombinedIgnoreList.Add(renderers[j]);
+                    m_CombinedIgnoreList.Add(renderers[j].gameObject);
                 }
             }
 

--- a/Scripts/Proxies/Data/ProxyFeedbackRequest.cs
+++ b/Scripts/Proxies/Data/ProxyFeedbackRequest.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using UnityEngine.InputNew;
 
@@ -52,7 +52,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
         /// <summary>
         /// The maximum number times to present this feedback
         /// </summary>
-        public int maxPresentations = 20;
+        public int maxPresentations = 2000000;
 
         /// <summary>
         /// (Optional) A delegate which returns true if presentation should be suppressed

--- a/Scripts/Proxies/Data/ProxyFeedbackRequest.cs
+++ b/Scripts/Proxies/Data/ProxyFeedbackRequest.cs
@@ -52,7 +52,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
         /// <summary>
         /// The maximum number times to present this feedback
         /// </summary>
-        public int maxPresentations = 2000000;
+        public int maxPresentations = 20;
 
         /// <summary>
         /// (Optional) A delegate which returns true if presentation should be suppressed

--- a/Scripts/Utilities/ObjectUtils.cs
+++ b/Scripts/Utilities/ObjectUtils.cs
@@ -93,12 +93,32 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
             return component;
         }
 
+        public static Bounds GetBounds(List<GameObject> gameObjects)
+        {
+            Bounds? bounds = null;
+            foreach (var gameObject in gameObjects)
+            {
+                var goBounds = GetBounds(gameObject.transform);
+                if (!bounds.HasValue)
+                {
+                    bounds = goBounds;
+                }
+                else
+                {
+                    goBounds.Encapsulate(bounds.Value);
+                    bounds = goBounds;
+                }
+            }
+
+            return bounds ?? new Bounds();
+        }
+
         public static Bounds GetBounds(Transform[] transforms)
         {
             Bounds? bounds = null;
-            foreach (var go in transforms)
+            foreach (var t in transforms)
             {
-                var goBounds = GetBounds(go);
+                var goBounds = GetBounds(t);
                 if (!bounds.HasValue)
                 {
                     bounds = goBounds;

--- a/Tools/LocomotionTool/Scripts/BlinkVisuals.cs
+++ b/Tools/LocomotionTool/Scripts/BlinkVisuals.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor.Experimental.EditorVR;
@@ -63,7 +63,7 @@ public class BlinkVisuals : MonoBehaviour, IUsesViewerScale, IRaycast
 
     public float extraSpeed { private get; set; }
 
-    public List<Renderer> ignoreList { private get; set; }
+    public List<GameObject> ignoreList { private get; set; }
 
     public bool visible
     {

--- a/Tools/SelectionTool/SelectionTool.cs
+++ b/Tools/SelectionTool/SelectionTool.cs
@@ -17,7 +17,8 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         ICanGrabObject, IGetManipulatorDragState, IUsesNode, IGetRayVisibility, IIsMainMenuVisible, IIsInMiniWorld,
         IRayToNode, IGetDefaultRayColor, ISetDefaultRayColor, ITooltip, ITooltipPlacement, ISetTooltipVisibility,
         IUsesDeviceType, IMenuIcon, IUsesPointer, IRayVisibilitySettings, IUsesViewerScale, ICheckBounds,
-        ISettingsMenuItemProvider, ISerializePreferences, IStandardIgnoreList, IBlockUIInteraction, IRequestFeedback
+        ISettingsMenuItemProvider, ISerializePreferences, IStandardIgnoreList, IBlockUIInteraction, IRequestFeedback,
+        IGetVRPlayerObjects
     {
         [Serializable]
         class Preferences
@@ -342,8 +343,10 @@ namespace UnityEditor.Experimental.EditorVR.Tools
                 if (hovered != null)
                     hovered(hoveredObject, rayOrigin);
 
-                if (!GetSelectionCandidate(ref hoveredObject))
-                    HideSelectFeedback();
+                GetSelectionCandidate(ref hoveredObject);
+
+                if (hoveredObject && this.GetVRPlayerObjects().Contains(hoveredObject))
+                    hoveredObject = null;
             }
 
             if (!hoveredObject)

--- a/Tools/SelectionTool/SelectionTool.cs
+++ b/Tools/SelectionTool/SelectionTool.cs
@@ -90,7 +90,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         public event Action<GameObject, Transform> hovered;
 
-        public List<Renderer> ignoreList { private get; set; }
+        public List<GameObject> ignoreList { private get; set; }
         public List<ILinkedObject> linkedObjects { get; set; }
 
         public string tooltipText { get { return m_MultiSelect ? "Multi-Select Enabled" : ""; } }


### PR DESCRIPTION
### Purpose of this PR

Fix an issue where "Select" feedback shows up when you point at your head. Fixes #351 

### Testing status

Tested in the latest EXR in Polygon Adventure Scene. Pointing at my head with feedback always-on (set maxpresentations to 200000) does not show Select feedback. Can still re-position head in miniworld

### Technical risk

Low - Mostly refactor code. Actual fix resides in SelectionTool

### Notes to reviewers

This looks a lot scarier than it is. I wanted to avoid having to GetComponent for the renderer in SelectionTool, and I think it makes sense in general for the ignore lists to be GameObjects. Previously, we were only ever dealing with renderers, so it made sense to use renderers. I don't think we will have the opposite issue (having to get renderers from the objects in the ignorelist) but if so, maybe we can hold a tuple of GameObject/Renderer.