### PR TITLE
Custom menus are hidden if the main menu is

### DIFF
--- a/Scripts/Core/EditorVR.Menus.cs
+++ b/Scripts/Core/EditorVR.Menus.cs
@@ -189,6 +189,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
                     MenuHideData alternateMenuData = null;
 
                     var mainMenuVisible = mainMenu != null && menuHideData[mainMenu].hideFlags == 0;
+                    var mainMenuSupressed = mainMenu != null && ((menuHideData[mainMenu].hideFlags & MenuHideFlags.Occluded) != 0);
+
                     var alternateMenuVisible = false;
                     if (alternateMenu != null)
                     {
@@ -216,8 +218,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
                         }
                     }
 
-                    // Temporarily hide customMenu if other menus are visible
-                    if (customMenuVisible && mainMenuVisible)
+                    // Temporarily hide customMenu if other menus are visible or should be
+                    if (customMenuVisible && (mainMenuVisible || mainMenuSupressed))
                         customMenuHideData.hideFlags |= MenuHideFlags.OtherMenu;
 
                     // Temporarily hide alternateMenu if other menus are visible

--- a/Scripts/Data/MenuHideFlags.cs
+++ b/Scripts/Data/MenuHideFlags.cs
@@ -15,7 +15,8 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         OverWorkspace = 1 << 3,
         HasDirectSelection = 1 << 4,
 
-        Temporary = OtherMenu | OverUI | OverWorkspace | HasDirectSelection
+        Temporary = OtherMenu | OverUI | OverWorkspace | HasDirectSelection,
+        Occluded = OverUI | OverWorkspace | HasDirectSelection
     }
 }
 #endif


### PR DESCRIPTION
### Purpose of this PR

Fixes #416 

Custom menus that occupy the same space as the main menu, will now be suppressed if the main menu is as well (in situations like hovering over other UI or workspaces

### Testing status

Tested in latest build over geo, workspaces, UI, and other tools

### Technical risk

Low - Custom menus linked to the hand are not used too widely yet, only effect is temporarily hiding a menu.