### PR TITLE
force Main Menu animation to set full blend weight at end

### DIFF
--- a/Menus/MainMenu/Scripts/MainMenuUI.cs
+++ b/Menus/MainMenu/Scripts/MainMenuUI.cs
@@ -490,8 +490,6 @@ namespace UnityEditor.Experimental.EditorVR.Menus
                 yield return null;
             }
 
-            m_VisibilityState = visibilityState;
-
             m_MenuFrameRenderer.SetBlendShapeWeight(1, targetWeight);
             m_MenuFacesMaterial.color = targetWeight > 0 ? m_MenuFacesColor : k_MenuFacesHiddenColor;
 

--- a/Menus/MainMenu/Scripts/MainMenuUI.cs
+++ b/Menus/MainMenu/Scripts/MainMenuUI.cs
@@ -492,12 +492,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
             m_VisibilityState = visibilityState;
 
-            if (m_VisibilityState != VisibilityState.Hidden)
-            {
-                m_MenuFrameRenderer.SetBlendShapeWeight(1, targetWeight);
-                m_MenuFacesMaterial.color = targetWeight > 0 ? m_MenuFacesColor : k_MenuFacesHiddenColor;
-            }
-            else
+            m_MenuFrameRenderer.SetBlendShapeWeight(1, targetWeight);
+            m_MenuFacesMaterial.color = targetWeight > 0 ? m_MenuFacesColor : k_MenuFacesHiddenColor;
+
+            if (m_VisibilityState == VisibilityState.Hidden)
             {
                 m_MenuFrameRenderer.SetBlendShapeWeight(0, 0);
             }

--- a/Menus/MainMenu/Scripts/MainMenuUI.cs
+++ b/Menus/MainMenu/Scripts/MainMenuUI.cs
@@ -481,7 +481,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
             currentBlendShapeWeight = currentBlendShapeWeight > 0 ? currentBlendShapeWeight : zeroStartBlendShapePadding;
 
             var currentDuration = 0f;
-            while (m_VisibilityState != VisibilityState.Hidden && currentDuration < smoothTime)
+            while (m_VisibilityState != VisibilityState.Hidden && currentDuration - Time.deltaTime < smoothTime)
             {
                 currentBlendShapeWeight = MathUtilsExt.SmoothDamp(currentBlendShapeWeight, targetWeight, ref smoothVelocity, smoothTime, Mathf.Infinity, Time.deltaTime);
                 currentDuration += Time.deltaTime;
@@ -490,14 +490,17 @@ namespace UnityEditor.Experimental.EditorVR.Menus
                 yield return null;
             }
 
-            if (m_VisibilityState == visibilityState)
+            m_VisibilityState = visibilityState;
+
+            if (m_VisibilityState != VisibilityState.Hidden)
             {
                 m_MenuFrameRenderer.SetBlendShapeWeight(1, targetWeight);
                 m_MenuFacesMaterial.color = targetWeight > 0 ? m_MenuFacesColor : k_MenuFacesHiddenColor;
             }
-
-            if (m_VisibilityState == VisibilityState.Hidden)
+            else
+            {
                 m_MenuFrameRenderer.SetBlendShapeWeight(0, 0);
+            }
         }
 
         public void OnRayEnter(RayEventData eventData)


### PR DESCRIPTION
fixes #433 

`currentDuration - Time.deltaTime` is to allow the lerp to run for another frame & get closer to the target weight, based on suggestion from @dunity 