### PR TITLE
Fix Unlock All button on LockedObjectsWorkspace

### DIFF
--- a/Workspaces/LockedObjectsWorkspace/LockedObjectsWorkspace.cs
+++ b/Workspaces/LockedObjectsWorkspace/LockedObjectsWorkspace.cs
@@ -1,5 +1,4 @@
 ﻿#if UNITY_EDITOR
-using System;
 using System.Collections.Generic;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
@@ -43,9 +42,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             }
         }
 
-        public Action<GameObject, bool> setLocked { get; set; }
-        public Func<GameObject, bool> isLocked { get; set; }
-
         public override void Setup()
         {
             base.Setup();
@@ -69,12 +65,15 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         void UnlockAll(List<HierarchyData> hierarchyData)
         {
-            if (hierarchyData == null)
+            if (hierarchyData == null || hierarchyData.Count == 0)
                 return;
+
+            if (!hierarchyData[0].gameObject)
+                hierarchyData = hierarchyData[0].children;
 
             foreach (var hd in hierarchyData)
             {
-                setLocked(hd.gameObject, false);
+                this.SetLocked(hd.gameObject, false);
 
                 UnlockAll(hd.children);
             }


### PR DESCRIPTION
Tiny little change:
- HierarchyData is now represented as a single root object with children, so we need to use the children list now when unlocking all.
- LockedObjectsWorkspace was not updated to the new style of Functionality Injection, so we don't need the delegate properties anymore