### PR TITLE
Fix Presentation/SmoothCamera enabled rotation

### DIFF
--- a/Scripts/Helpers/VRSmoothCamera.cs
+++ b/Scripts/Helpers/VRSmoothCamera.cs
@@ -79,6 +79,13 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
             m_Rotation = transform.localRotation;
         }
 
+        void OnEnable()
+        {
+            // Prevent camera from performing a very fast (shortest path) rotational correction when being enabled
+            if (m_VRCamera)
+                m_Rotation = m_VRCamera.transform.localRotation;
+        }
+
         void LateUpdate()
         {
             m_SmoothCamera.CopyFrom(m_VRCamera); // This copies the transform as well

--- a/Scripts/Helpers/VRSmoothCamera.cs
+++ b/Scripts/Helpers/VRSmoothCamera.cs
@@ -81,9 +81,12 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 
         void OnEnable()
         {
-            // Prevent camera from performing a very fast (shortest path) rotational correction when being enabled
+            // Snap camera to starting position
             if (m_VRCamera)
+            {
                 m_Rotation = m_VRCamera.transform.localRotation;
+                m_Position = m_VRCamera.transform.localPosition;
+            }
         }
 
         void LateUpdate()


### PR DESCRIPTION
### Purpose of this PR

Prevent Presentation/SmoothCamera from performing a very fast (shortest path) rotation correction when being enabled : https://github.com/Unity-Technologies/EditorVR/issues/441

### Testing status

Tested numerous times; no issues arose in the tests.

### Technical risk

Low: There's not much to this but setting m_Rotation in OnEnable().

### Notes

When toggling the presentation camera setting, the noticeable roll rotation difference/correction between the VRCamera & the VRSmoothCamera is to be expected.  Though, the (now fixed) odd correction/lerp of the previous m_Rotation value should not be present.