### PR TITLE
Fix exception when loading Poly workspace in project without Poly Toolkit

### DIFF
--- a/Scripts/Modules/WorkspaceModule.cs
+++ b/Scripts/Modules/WorkspaceModule.cs
@@ -167,6 +167,9 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
         internal void CreateWorkspace(Type t, Action<IWorkspace> createdCallback = null)
         {
+            if (!typeof(IWorkspace).IsAssignableFrom(t))
+                return;
+
             // HACK: MiniWorldWorkspace is not working in single pass yet
             if (t == typeof(MiniWorldWorkspace) && PlayerSettings.stereoRenderingPath != StereoRenderingPath.MultiPass)
             {


### PR DESCRIPTION
If you open EditorXR with a serialized Poly workspace in a project without the PolyToolkit, you get an exception trying to load the previous state. The issue is that the PolyWorkspace stub is just a plain monobehaviour and we can't cast it to IWorkspace.