### PR TITLE
Undo patch fix

### DIFF
--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using UnityEngine.InputNew;
 
 [assembly: OptionalDependency("PolyToolkit.PolyApi", "INCLUDE_POLY_TOOLKIT")]
+[assembly: OptionalDependency("UnityEngine.DrivenRectTransformTracker+BlockUndoCCU", "UNDO_PATCH")]
 
 namespace UnityEditor.Experimental.EditorVR.Core
 {
@@ -126,6 +127,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         void Awake()
         {
+#if UNDO_PATCH
+            DrivenRectTransformTracker.BlockUndo = true;
+#endif
             s_Instance = this; // Used only by PreferencesGUI
             Nested.evr = this; // Set this once for the convenience of all nested classes
             m_DefaultTools = defaultTools;
@@ -346,6 +350,10 @@ namespace UnityEditor.Experimental.EditorVR.Core
             {
                 nested.OnDestroy();
             }
+
+#if UNDO_PATCH
+            DrivenRectTransformTracker.BlockUndo = false;
+#endif
         }
 
         void Update()

--- a/UndoPatch.meta
+++ b/UndoPatch.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 09bef22b7a38b1748826705905670959
+folderAsset: yes
+timeCreated: 1512465425
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UndoPatch/UnityEngine.CoreModule_2017.2.0p1.zip
+++ b/UndoPatch/UnityEngine.CoreModule_2017.2.0p1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:263509d40ec2fe536344bfaf6e74c421d384466634e67e6b46039f96931a5834
+size 248879

--- a/UndoPatch/UnityEngine.CoreModule_2017.2.0p1.zip.meta
+++ b/UndoPatch/UnityEngine.CoreModule_2017.2.0p1.zip.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 91ff1c9c19344e04b814821f72db55a8
+timeCreated: 1512465425
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes the frequent "Driving RectTransform" undo actions registered by RectTransform by setting a static bool in a patched version of UnityEngine.CoreModule.dll.

To apply the patch, manually unzip the patched dll and overwrite the version in
<Unity>\Editor\Data\Managed\UnityEngine

We will need to provide patched versions for any Unity version we support. Thankfully the source modification basically just adds the static bool and checks it in two places (and adds the empty class for the CCU to pick up on). We will probably only support major releases until we find a more permanent solution. And we'll want to add patch instructions to the docs.

For the best testing experience, merge this into features/jono/undo-redo-flick (and copy the dll into Program Files, of course).