### PR TITLE
Fix Miniworld Snapping bug

### DIFF
--- a/Scripts/Core/EditorVR.MiniWorlds.cs
+++ b/Scripts/Core/EditorVR.MiniWorlds.cs
@@ -383,8 +383,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
                             directSelection.ResumeGrabbers(incomingPreview.node);
                         }
 
-                        miniWorldRay.UpdatePreview(); // Otherwise the object is in the wrong position for a frame
-
                         if (!isContained)
                             m_RayWasContained[originalRayOrigin] = false; //Prevent ray from showing
                     }

--- a/Tools/TransformTool/TransformTool.cs
+++ b/Tools/TransformTool/TransformTool.cs
@@ -58,7 +58,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
                 }
             }
 
-            public void UpdatePositions(IUsesSnapping usesSnapping)
+            public void UpdatePositions(IUsesSnapping usesSnapping, bool interpolate = true)
             {
                 if (suspended)
                     return;
@@ -75,9 +75,17 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
                     if (usesSnapping.DirectSnap(rayOrigin, grabbedObject, ref position, ref rotation, targetPosition, targetRotation))
                     {
-                        var deltaTime = Time.deltaTime;
-                        grabbedObject.position = Vector3.Lerp(grabbedObject.position, position, k_DirectLazyFollowTranslate * deltaTime);
-                        grabbedObject.rotation = Quaternion.Lerp(grabbedObject.rotation, rotation, k_DirectLazyFollowRotate * deltaTime);
+                        if (interpolate)
+                        {
+                            var deltaTime = Time.deltaTime;
+                            grabbedObject.position = Vector3.Lerp(grabbedObject.position, position, k_DirectLazyFollowTranslate * deltaTime);
+                            grabbedObject.rotation = Quaternion.Lerp(grabbedObject.rotation, rotation, k_DirectLazyFollowRotate * deltaTime);
+                        }
+                        else
+                        {
+                            grabbedObject.position = position;
+                            grabbedObject.rotation = rotation;
+                        }
                     }
                     else
                     {
@@ -595,7 +603,10 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         {
             var grabData = GrabDataForNode(node);
             if (grabData != null)
+            {
                 grabData.suspended = false;
+                grabData.UpdatePositions(this, false);
+            }
         }
 
         public Transform[] GetHeldObjects(Node node)
@@ -616,7 +627,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
             grabData.TransferTo(destRayOrigin, deltaOffset);
             this.ClearSnappingState(rayOrigin);
-            grabData.UpdatePositions(this);
+            grabData.UpdatePositions(this, false);
 
             // Prevent lock from getting stuck
             this.RemoveRayVisibilitySettings(rayOrigin, this);


### PR DESCRIPTION
**Purpose of this PR**
Fixes #268. Because objects interpolate position when they are snapping, we had an undesired behavior where objects entering the minworld, and immediately engaging snapping, would quickly fly into place in a jarring fashion. 

The fix is to hard-set the snap position the first frame they enter the miniworld, which maintains the "this is the same object" illusion.

**Testing status**

Tested on Vive in the Polygon Adventure scene. To reproduce the issue pre-fix, just grab an object, find a place in the mini world where it will snap right at the edge of the miniworld volume, and move the object in and out of the miniworld. You should see it fly away from your hand and back into view within the miniworld. With the fix applied, it should just "pop" into the miniworld in the snapped position

**Technical risk**

Low: This only affects the frame when an object enters the miniworld

**Comments to reviewers**

The change to TransferHeldObjects is not represented in this repro case, but the same hard-set makes sense in that situation.