### PR TITLE
Hierarchy Drop bug

### DIFF
--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
@@ -509,8 +509,11 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             {
                 var index = data.index;
                 var gameObject = data.gameObject;
+                Transform transform = null;
+                if (gameObject != null) // In case we are dropping into the scene root
+                    transform = gameObject.transform;
+
                 var dropGameObject = dropData.gameObject;
-                var transform = gameObject.transform;
                 var dropTransform = dropGameObject.transform;
 
                 // OnHierarchyChanged doesn't happen until next frame--delay removal of the extra space


### PR DESCRIPTION
There was a bug due to an old refactor of GetHierarchyData which caused objects dropped into the scene root (when re-ordering hierarchy) to cause a null ref.  We have a HierarchyData for the root which we didn't used to have, but it has a null gameobject, since there's no gameobject at the scene root.