### PR TITLE
consume vacuum double click control

### DIFF
--- a/Tools/VacuumTool/VacuumTool.cs
+++ b/Tools/VacuumTool/VacuumTool.cs
@@ -59,6 +59,8 @@ namespace UnityEditor.Experimental.EditorVR.Tools
                         var realTime = Time.realtimeSinceStartup;
                         if (UIUtils.IsDoubleClick(realTime - m_LastClickTime))
                         {
+                            consumeControl(vacuumInput.vacuum);
+
                             Coroutine coroutine;
                             if (m_VacuumingCoroutines.TryGetValue(vacuumableTransform, out coroutine))
                                 StopCoroutine(coroutine);


### PR DESCRIPTION
this prevents Multi-select from being enabled when you vacuum a workspace.