### PR TITLE
Bring back Vive "pip"

### DIFF
--- a/Prefabs/Proxies/LeftTouch.prefab
+++ b/Prefabs/Proxies/LeftTouch.prefab
@@ -2256,45 +2256,65 @@ MonoBehaviour:
     type: 2}
   m_Affordances:
   - m_Control: 2
-    m_Transform: {fileID: 4023718469717780}
-    m_Renderer: {fileID: 13787692}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4023718469717780}
+    m_Renderers:
+    - {fileID: 13787692}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114015681421713280}
   - m_Control: 3
-    m_Transform: {fileID: 450394}
-    m_Renderer: {fileID: 13767942}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 450394}
+    m_Renderers:
+    - {fileID: 13767942}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114126251981801024}
   - m_Control: 17
-    m_Transform: {fileID: 442622}
-    m_Renderer: {fileID: 13771122}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 442622}
+    m_Renderers:
+    - {fileID: 13771122}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114720817646417354}
   - m_Control: 18
-    m_Transform: {fileID: 447250}
-    m_Renderer: {fileID: 13791068}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 447250}
+    m_Renderers:
+    - {fileID: 13791068}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114626331710630820}
   - m_Control: 22
-    m_Transform: {fileID: 407362}
-    m_Renderer: {fileID: 13758356}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 407362}
+    m_Renderers:
+    - {fileID: 13758356}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114996085697448538}
   - m_Control: 0
-    m_Transform: {fileID: 407362}
-    m_Renderer: {fileID: 13758356}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 407362}
+    m_Renderers:
+    - {fileID: 13758356}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114937140451437304}
   - m_Control: 1
-    m_Transform: {fileID: 407362}
-    m_Renderer: {fileID: 13758356}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 407362}
+    m_Renderers:
+    - {fileID: 13758356}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114227371692010420}
 --- !u!114 &114957305131514852

--- a/Prefabs/Proxies/LeftTouchOpenVR.prefab
+++ b/Prefabs/Proxies/LeftTouchOpenVR.prefab
@@ -1885,45 +1885,66 @@ MonoBehaviour:
     type: 2}
   m_Affordances:
   - m_Control: 2
-    m_Transform: {fileID: 4739757693524634}
-    m_Renderer: {fileID: 137827934778804418}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4739757693524634}
+    m_Renderers:
+    - {fileID: 137827934778804418}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114178244051393772}
   - m_Control: 3
-    m_Transform: {fileID: 4520968933053068}
-    m_Renderer: {fileID: 137809521931614260}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4520968933053068}
+    m_Renderers:
+    - {fileID: 137809521931614260}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114208349049674382}
   - m_Control: 17
-    m_Transform: {fileID: 4822934406098802}
-    m_Renderer: {fileID: 137279077384400616}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4822934406098802}
+    m_Renderers:
+    - {fileID: 137279077384400616}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114474480701569528}
   - m_Control: 18
-    m_Transform: {fileID: 4987518757343592}
-    m_Renderer: {fileID: 137445039977449418}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4987518757343592}
+    m_Renderers:
+    - {fileID: 137445039977449418}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114933204733924580}
   - m_Control: 22
-    m_Transform: {fileID: 4490380767236794}
-    m_Renderer: {fileID: 137862233404870076}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4490380767236794}
+    m_Renderers:
+    - {fileID: 137862233404870076}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114125306406013188}
   - m_Control: 0
-    m_Transform: {fileID: 4490380767236794}
-    m_Renderer: {fileID: 137862233404870076}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4490380767236794}
+    m_Renderers:
+    - {fileID: 137862233404870076}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114337431156793536}
   - m_Control: 1
-    m_Transform: {fileID: 4490380767236794}
-    m_Renderer: {fileID: 137862233404870076}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4490380767236794}
+    m_Renderers:
+    - {fileID: 137862233404870076}
+
+    m_Materials: []
+
     m_Tooltips:
     - {fileID: 114807140885831364}
 --- !u!114 &114933204733924580

--- a/Prefabs/Proxies/RightTouch.prefab
+++ b/Prefabs/Proxies/RightTouch.prefab
@@ -1890,45 +1890,66 @@ MonoBehaviour:
     type: 2}
   m_Affordances:
   - m_Control: 2
-    m_Transform: {fileID: 482366}
-    m_Renderer: {fileID: 13788364}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 482366}
+    m_Renderers:
+    - {fileID: 13788364}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114431176106213124}
   - m_Control: 3
-    m_Transform: {fileID: 431526}
-    m_Renderer: {fileID: 13791512}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 431526}
+    m_Renderers:
+    - {fileID: 13791512}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114710602601813986}
   - m_Control: 17
-    m_Transform: {fileID: 412818}
-    m_Renderer: {fileID: 13757144}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 412818}
+    m_Renderers:
+    - {fileID: 13757144}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114587196572306994}
   - m_Control: 18
-    m_Transform: {fileID: 437054}
-    m_Renderer: {fileID: 13724278}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 437054}
+    m_Renderers:
+    - {fileID: 13724278}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114526162600788140}
   - m_Control: 22
-    m_Transform: {fileID: 451284}
-    m_Renderer: {fileID: 13768278}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 451284}
+    m_Renderers:
+    - {fileID: 13768278}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114564303215576146}
   - m_Control: 0
-    m_Transform: {fileID: 451284}
-    m_Renderer: {fileID: 13768278}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 451284}
+    m_Renderers:
+    - {fileID: 13768278}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114088248147605316}
   - m_Control: 1
-    m_Transform: {fileID: 451284}
-    m_Renderer: {fileID: 13768278}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 451284}
+    m_Renderers:
+    - {fileID: 13768278}
+
+    m_Materials: []
+
     m_Tooltips:
     - {fileID: 114382005819407472}
 --- !u!114 &114378051109309934

--- a/Prefabs/Proxies/RightTouchOpenVR.prefab
+++ b/Prefabs/Proxies/RightTouchOpenVR.prefab
@@ -1615,45 +1615,66 @@ MonoBehaviour:
     type: 2}
   m_Affordances:
   - m_Control: 2
-    m_Transform: {fileID: 4199321456540786}
-    m_Renderer: {fileID: 137005679053573082}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4199321456540786}
+    m_Renderers:
+    - {fileID: 137005679053573082}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114106734160267480}
   - m_Control: 3
-    m_Transform: {fileID: 4010047915957694}
-    m_Renderer: {fileID: 137200858950391162}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4010047915957694}
+    m_Renderers:
+    - {fileID: 137200858950391162}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114427722552533374}
   - m_Control: 17
-    m_Transform: {fileID: 4221126147080902}
-    m_Renderer: {fileID: 137136063802218740}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4221126147080902}
+    m_Renderers:
+    - {fileID: 137136063802218740}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114041942050554804}
   - m_Control: 18
-    m_Transform: {fileID: 4022345611153456}
-    m_Renderer: {fileID: 137918311825069984}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4022345611153456}
+    m_Renderers:
+    - {fileID: 137918311825069984}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114698121262855600}
   - m_Control: 22
-    m_Transform: {fileID: 4662592250246964}
-    m_Renderer: {fileID: 137123611090237704}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4662592250246964}
+    m_Renderers:
+    - {fileID: 137123611090237704}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114510401113800598}
   - m_Control: 0
-    m_Transform: {fileID: 4662592250246964}
-    m_Renderer: {fileID: 137123611090237704}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4662592250246964}
+    m_Renderers:
+    - {fileID: 137123611090237704}
+
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114195443192961852}
   - m_Control: 1
-    m_Transform: {fileID: 4662592250246964}
-    m_Renderer: {fileID: 137123611090237704}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4662592250246964}
+    m_Renderers:
+    - {fileID: 137123611090237704}
+
+    m_Materials: []
+
     m_Tooltips:
     - {fileID: 114178596385280704}
 --- !u!114 &114348725268908826

--- a/Prefabs/Proxies/ViveController.prefab
+++ b/Prefabs/Proxies/ViveController.prefab
@@ -721,6 +721,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1937968145898116
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4267069473354514}
+  - component: {fileID: 33016647632292958}
+  - component: {fileID: 23228397771655312}
+  m_Layer: 0
+  m_Name: track_pip_group1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1947939447631840
 GameObject:
   m_ObjectHideFlags: 1
@@ -749,6 +766,21 @@ GameObject:
   - component: {fileID: 23772360735447006}
   m_Layer: 0
   m_Name: menu_but_group1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1967335880900170
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4278513193597556}
+  m_Layer: 0
+  m_Name: trackpad_touch
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -883,6 +915,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4788207952759710}
+  - {fileID: 4278513193597556}
   m_Father: {fileID: 4469504124180788}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 6.5350003, y: 0, z: 0}
@@ -928,7 +961,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1225174784619462}
   m_LocalRotation: {x: 0, y: 0.8762647, z: -0.4818301, w: 0}
-  m_LocalPosition: {x: 0.0778, y: 0.0026, z: 0.0999}
+  m_LocalPosition: {x: 0.0425, y: 0.0026, z: 0.0999}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4035010716147694}
@@ -941,7 +974,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1547906465118038}
   m_LocalRotation: {x: -0, y: 0.2789073, z: -0.960318, w: 0}
-  m_LocalPosition: {x: 0.0738, y: 0.0187, z: 0.0012}
+  m_LocalPosition: {x: 0.0495, y: 0.0187, z: 0.0012}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4449357101051952}
@@ -980,7 +1013,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1690274936479956}
   m_LocalRotation: {x: -0, y: 0.8762647, z: -0.48183012, w: 0}
-  m_LocalPosition: {x: -0.0793, y: 0.010199993, z: 0.0063000116}
+  m_LocalPosition: {x: -0.04879999, y: 0.010199993, z: 0.0063000116}
   m_LocalScale: {x: 1, y: 1, z: 1.0000001}
   m_Children: []
   m_Father: {fileID: 4035010716147694}
@@ -1000,6 +1033,19 @@ Transform:
   m_Father: {fileID: 4469504124180788}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 4.8490005, y: 3.49, z: 24.451}
+--- !u!4 &4267069473354514
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1937968145898116}
+  m_LocalRotation: {x: -0.05699771, y: -0, z: -0, w: 0.99837434}
+  m_LocalPosition: {x: 0, y: -0.009365969, z: -0.04845892}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4278513193597556}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4268880949599228
 Transform:
   m_ObjectHideFlags: 1
@@ -1013,6 +1059,20 @@ Transform:
   m_Father: {fileID: 4432114245915554}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4278513193597556
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1967335880900170}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4267069473354514}
+  m_Father: {fileID: 4027072583190098}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4286430755920000
 Transform:
   m_ObjectHideFlags: 1
@@ -1020,7 +1080,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1975974212585692}
   m_LocalRotation: {x: 0, y: 0.8762647, z: -0.4818301, w: 0}
-  m_LocalPosition: {x: 0.0791, y: 0.0102, z: 0.0062999995}
+  m_LocalPosition: {x: 0.0488, y: 0.0102, z: 0.0062999995}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4035010716147694}
@@ -1046,7 +1106,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1299922452772042}
   m_LocalRotation: {x: -0, y: 0.27890733, z: -0.9603181, w: 0}
-  m_LocalPosition: {x: 0.0718, y: 0.011599995, z: 0.10210002}
+  m_LocalPosition: {x: 0.042499993, y: 0.011599995, z: 0.10210002}
   m_LocalScale: {x: 1, y: 1.0000005, z: 1}
   m_Children: []
   m_Father: {fileID: 4449357101051952}
@@ -1059,7 +1119,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1684975939010892}
   m_LocalRotation: {x: 0, y: 0.8762647, z: -0.4818301, w: 0}
-  m_LocalPosition: {x: 0.0877, y: 0.0059, z: 0.0657}
+  m_LocalPosition: {x: 0.0449, y: 0.0059, z: 0.0657}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4035010716147694}
@@ -1072,7 +1132,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1057360148245394}
   m_LocalRotation: {x: 0, y: 0.2789073, z: -0.9603181, w: 0}
-  m_LocalPosition: {x: -0.0872, y: -0.0125, z: 0.0503}
+  m_LocalPosition: {x: -0.047, y: -0.0125, z: 0.0503}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4449357101051952}
@@ -1211,7 +1271,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1112519066469124}
   m_LocalRotation: {x: -0, y: 0.8762647, z: -0.48183012, w: 0}
-  m_LocalPosition: {x: -0.0876, y: 0.007299993, z: 0.03500002}
+  m_LocalPosition: {x: -0.04699999, y: 0.007299993, z: 0.03500002}
   m_LocalScale: {x: 1, y: 1, z: 1.0000001}
   m_Children: []
   m_Father: {fileID: 4035010716147694}
@@ -1238,7 +1298,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1947939447631840}
   m_LocalRotation: {x: -0, y: 0.27890733, z: -0.9603181, w: 0}
-  m_LocalPosition: {x: -0.0727, y: 0.018699987, z: 0.0012000217}
+  m_LocalPosition: {x: -0.04950001, y: 0.018699987, z: 0.0012000217}
   m_LocalScale: {x: 1, y: 1.0000005, z: 1}
   m_Children: []
   m_Father: {fileID: 4449357101051952}
@@ -1251,7 +1311,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1782288131876036}
   m_LocalRotation: {x: -0, y: 0.8762647, z: -0.48183012, w: 0}
-  m_LocalPosition: {x: -0.0763, y: 0.0025999844, z: 0.09990003}
+  m_LocalPosition: {x: -0.04249999, y: 0.0025999844, z: 0.09990003}
   m_LocalScale: {x: 1, y: 1, z: 1.0000001}
   m_Children: []
   m_Father: {fileID: 4035010716147694}
@@ -1277,7 +1337,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1537308548188052}
   m_LocalRotation: {x: -0, y: 0.2789073, z: -0.960318, w: 0}
-  m_LocalPosition: {x: -0.0735, y: 0.011600018, z: 0.102110185}
+  m_LocalPosition: {x: -0.042500004, y: 0.011600018, z: 0.102110185}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4449357101051952}
@@ -1290,7 +1350,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1185558813916894}
   m_LocalRotation: {x: -0, y: 0.27890733, z: -0.9603181, w: 0}
-  m_LocalPosition: {x: -0.0875, y: 0.04039999, z: 0.056800015}
+  m_LocalPosition: {x: -0.0449, y: 0.04039999, z: 0.056800015}
   m_LocalScale: {x: 1, y: 1.0000005, z: 1}
   m_Children: []
   m_Father: {fileID: 4449357101051952}
@@ -1303,7 +1363,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1639276185918900}
   m_LocalRotation: {x: -0, y: 0.8762647, z: -0.48183012, w: 0}
-  m_LocalPosition: {x: -0.088, y: 0.0058999956, z: 0.06570001}
+  m_LocalPosition: {x: -0.0449, y: 0.0058999956, z: 0.06570001}
   m_LocalScale: {x: 1, y: 1, z: 1.0000001}
   m_Children: []
   m_Father: {fileID: 4035010716147694}
@@ -1329,7 +1389,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1605934862968814}
   m_LocalRotation: {x: -0, y: 0.27890733, z: -0.9603181, w: 0}
-  m_LocalPosition: {x: 0.0878, y: -0.012500018, z: 0.050300024}
+  m_LocalPosition: {x: 0.04699999, y: -0.012500018, z: 0.050300024}
   m_LocalScale: {x: 1, y: 1.0000005, z: 1}
   m_Children: []
   m_Father: {fileID: 4449357101051952}
@@ -1355,7 +1415,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1727178761897516}
   m_LocalRotation: {x: 0, y: 0.8762647, z: -0.4818301, w: 0}
-  m_LocalPosition: {x: 0.0877, y: 0.0073, z: 0.035}
+  m_LocalPosition: {x: 0.047, y: 0.0073, z: 0.035}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4035010716147694}
@@ -1368,7 +1428,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1238159370474176}
   m_LocalRotation: {x: 0, y: 0.2789073, z: -0.9603181, w: 0}
-  m_LocalPosition: {x: 0.0885, y: 0.0404, z: 0.0568}
+  m_LocalPosition: {x: 0.0449, y: 0.0404, z: 0.0568}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4449357101051952}
@@ -1465,6 +1525,40 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1723382491159284}
   m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: b0cbe6ebb5130174ea902e4e160468b9, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!23 &23228397771655312
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1937968145898116}
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -1730,6 +1824,13 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!33 &33016647632292958
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1937968145898116}
+  m_Mesh: {fileID: 4300000, guid: 8fca69da58fb5a44ba6d838685744c73, type: 3}
 --- !u!33 &33026695381748044
 MeshFilter:
   m_ObjectHideFlags: 1
@@ -2183,47 +2284,65 @@ MonoBehaviour:
     type: 2}
   m_Affordances:
   - m_Control: 2
-    m_Transform: {fileID: 4539810040550546}
-    m_Renderer: {fileID: 23334373145171194}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4539810040550546}
+    m_Renderers:
+    - {fileID: 23334373145171194}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114185068079462814}
   - m_Control: 3
-    m_Transform: {fileID: 4064835649293204}
-    m_Renderer: {fileID: 23569124774784352}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4064835649293204}
+    m_Renderers:
+    - {fileID: 23569124774784352}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114116332399531262}
     - {fileID: 114195992931318178}
   - m_Control: 3
-    m_Transform: {fileID: 4233998180511522}
-    m_Renderer: {fileID: 23366012271666804}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4233998180511522}
+    m_Renderers:
+    - {fileID: 23366012271666804}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114195992931318178}
     - {fileID: 114116332399531262}
   - m_Control: 18
-    m_Transform: {fileID: 4851027070737694}
-    m_Renderer: {fileID: 23772360735447006}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4851027070737694}
+    m_Renderers:
+    - {fileID: 23772360735447006}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114819021981951190}
   - m_Control: 22
-    m_Transform: {fileID: 4027072583190098}
-    m_Renderer: {fileID: 23166709740205842}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4027072583190098}
+    m_Renderers:
+    - {fileID: 23166709740205842}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114055751475063944}
   - m_Control: 0
-    m_Transform: {fileID: 4027072583190098}
-    m_Renderer: {fileID: 23166709740205842}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4027072583190098}
+    - {fileID: 4278513193597556}
+    m_Renderers:
+    - {fileID: 23166709740205842}
+    - {fileID: 23228397771655312}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114396238560582176}
   - m_Control: 1
-    m_Transform: {fileID: 4027072583190098}
-    m_Renderer: {fileID: 23166709740205842}
-    m_Material: {fileID: 0}
+    m_Transforms:
+    - {fileID: 4027072583190098}
+    - {fileID: 4278513193597556}
+    m_Renderers:
+    - {fileID: 23166709740205842}
+    - {fileID: 23228397771655312}
+    m_Materials: []
     m_Tooltips:
     - {fileID: 114548104952197750}
 --- !u!114 &114660827611401952

--- a/Scripts/Proxies/Data/Affordance.cs
+++ b/Scripts/Proxies/Data/Affordance.cs
@@ -15,22 +15,22 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
         VRInputDevice.VRControl m_Control;
 
         [SerializeField]
-        Transform m_Transform;
+        Transform[] m_Transforms;
 
         [SerializeField]
-        Renderer m_Renderer;
+        Renderer[] m_Renderers;
 
-        [Tooltip("(Optional) Specific material for this affordance. If null, all materials are used")]
+        [Tooltip("(Optional) Specific materials for this affordance. If null, all materials are used")]
         [SerializeField]
-        Material m_Material;
+        Material[] m_Materials;
 
         [SerializeField]
         AffordanceTooltip[] m_Tooltips;
 
         public VRInputDevice.VRControl control { get { return m_Control; } }
-        public Transform transform { get { return m_Transform; } }
-        public Renderer renderer { get { return m_Renderer; } }
-        public Material material { get { return m_Material; } }
+        public Transform[] transforms { get { return m_Transforms; } }
+        public Renderer[] renderers { get { return m_Renderers; } }
+        public Material[] materials { get { return m_Materials; } }
         public AffordanceTooltip[] tooltips { get { return m_Tooltips; } }
     }
 }

--- a/Scripts/Proxies/Data/AffordanceDefinition.cs
+++ b/Scripts/Proxies/Data/AffordanceDefinition.cs
@@ -15,10 +15,10 @@ namespace UnityEditor.Experimental.EditorVR.Core
         VRInputDevice.VRControl m_Control;
 
         [SerializeField]
-        AffordanceAnimationDefinition m_AnimationDefinition;
+        AffordanceAnimationDefinition[] m_AnimationDefinitions;
 
         [SerializeField]
-        AffordanceVisibilityDefinition m_VisibilityDefinition;
+        AffordanceVisibilityDefinition[] m_VisibilityDefinitions;
 
         /// <summary>
         /// The control associated with this affordance
@@ -32,19 +32,19 @@ namespace UnityEditor.Experimental.EditorVR.Core
         /// <summary>
         /// The visibility definition used to drive changes to the visual elements representing this affordance
         /// </summary>
-        public AffordanceVisibilityDefinition visibilityDefinition
+        public AffordanceVisibilityDefinition[] visibilityDefinitions
         {
-            get { return m_VisibilityDefinition; }
-            set { m_VisibilityDefinition = value; }
+            get { return m_VisibilityDefinitions; }
+            set { m_VisibilityDefinitions = value; }
         }
 
         /// <summary>
         /// The animation definition used to drive translation/rotation changes to the visual elements representing this affordance
         /// </summary>
-        public AffordanceAnimationDefinition animationDefinition
+        public AffordanceAnimationDefinition[] animationDefinitions
         {
-            get { return m_AnimationDefinition; }
-            set { m_AnimationDefinition = value; }
+            get { return m_AnimationDefinitions; }
+            set { m_AnimationDefinitions = value; }
         }
     }
 }

--- a/Scripts/Proxies/ProxyAnimator.cs
+++ b/Scripts/Proxies/ProxyAnimator.cs
@@ -83,18 +83,25 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
                     }
                 }
 
-                foreach (var affordance in m_Affordances)
+                for (var i = 0; i < m_Affordances.Length; i++)
                 {
-                    var affordanceTransform = affordance.transform;
-                    TransformInfo info;
-                    if (!m_TransformInfos.TryGetValue(affordanceTransform, out info))
+                    var affordance = m_Affordances[i];
+                    var transforms = affordance.transforms;
+                    foreach (var transform in transforms)
                     {
-                        info = new TransformInfo();
-                        m_TransformInfos[affordanceTransform] = info;
+                        TransformInfo info;
+                        if (!m_TransformInfos.TryGetValue(transform, out info))
+                        {
+                            info = new TransformInfo();
+                            m_TransformInfos[transform] = info;
+                        }
+
+                        info.initialPosition = transform.localPosition;
+                        info.initialRotation = transform.localRotation.eulerAngles;
                     }
 
-                    info.initialPosition = affordanceTransform.localPosition;
-                    info.initialRotation = affordanceTransform.localRotation.eulerAngles;
+                    if (m_Controls[i] == null)
+                        Debug.LogError(string.Format("Affordance defined for missing control {0}", affordance.control));
                 }
             }
 
@@ -110,24 +117,30 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
                 var affordance = m_Affordances[i];
                 var inputControl = m_Controls[i];
                 var controlIndex = affordance.control;
-                foreach (var definition in m_AffordanceDefinitions)
+                foreach (var affordanceDefinition in m_AffordanceDefinitions)
                 {
-                    if (definition.control == controlIndex)
+                    if (affordanceDefinition.control == controlIndex)
                     {
-                        var animationDefinition = definition.animationDefinition;
+                        var definitions = affordanceDefinition.animationDefinitions;
 
                         // Animate any values defined in the ProxyAffordanceMap's Affordance Definition
                         //Assume control values are [-1, 1]
-                        if (animationDefinition != null)
+                        if (definitions != null)
                         {
-                            var info = m_TransformInfos[affordance.transform];
-                            var handednessScalar = node == Node.RightHand && animationDefinition.reverseForRightHand ? -1 : 1;
-                            var min = animationDefinition.min * handednessScalar;
-                            var max = animationDefinition.max * handednessScalar;
-                            var offset = min + (inputControl.rawValue + 1) * (max - min) * 0.5f;
+                            var transforms = affordance.transforms;
+                            for (var j = 0; j < transforms.Length; j++)
+                            {
+                                var transform = transforms[j];
+                                var definition = definitions[j];
+                                var info = m_TransformInfos[transform];
+                                var handednessScalar = node == Node.RightHand && definition.reverseForRightHand ? -1 : 1;
+                                var min = definition.min * handednessScalar;
+                                var max = definition.max * handednessScalar;
+                                var offset = min + (inputControl.rawValue + 1) * (max - min) * 0.5f;
 
-                            info.positionOffset += animationDefinition.translateAxes.GetAxis() * offset;
-                            info.rotationOffset += animationDefinition.rotateAxes.GetAxis() * offset;
+                                info.positionOffset += definition.translateAxes.GetAxis() * offset;
+                                info.rotationOffset += definition.rotateAxes.GetAxis() * offset;
+                            }
                         }
 
                         break;

--- a/Scripts/Proxies/ProxyNode.cs
+++ b/Scripts/Proxies/ProxyNode.cs
@@ -240,21 +240,28 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 
             readonly Dictionary<Material, MaterialData> m_MaterialDictionary = new Dictionary<Material, MaterialData>();
 
-            public void AddAffordance(Affordance affordance, AffordanceVisibilityDefinition definition)
+            public void AddAffordance(Affordance affordance, AffordanceVisibilityDefinition[] definitions)
             {
                 var control = affordance.control;
-                var targetMaterial = affordance.material;
-                var renderer = affordance.renderer;
+                var materials = affordance.materials;
+                var renderers = affordance.renderers;
                 var tooltips = affordance.tooltips;
-                if (targetMaterial != null)
+                if (materials != null)
                 {
-                    AddMaterialData(targetMaterial, control, renderer, tooltips, definition);
+                    for (var i = 0; i < materials.Length; i++)
+                    {
+                        AddMaterialData(materials[i], control, renderers[i], tooltips, definitions[i]);
+                    }
                 }
                 else
                 {
-                    foreach (var material in renderer.sharedMaterials)
+                    for (var i = 0; i < renderers.Length; i++)
                     {
-                        AddMaterialData(material, control, renderer, tooltips, definition);
+                        var renderer = renderers[i];
+                        foreach (var material in renderer.sharedMaterials)
+                        {
+                            AddMaterialData(material, control, renderer, tooltips, definitions[i]);
+                        }
                     }
                 }
             }
@@ -422,36 +429,39 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
             for (var i = 0; i < m_Affordances.Length; i++)
             {
                 var affordance = m_Affordances[i];
-                var renderer = affordance.renderer;
-                var sharedMaterials = renderer.sharedMaterials;
-                AffordanceData affordanceData;
-                if (!m_AffordanceData.TryGetValue(renderer, out affordanceData))
+                var renderers = affordance.renderers;
+                foreach (var renderer in renderers)
                 {
-                    MaterialUtils.CloneMaterials(renderer); // Clone all materials associated with each renderer once
-                    affordanceData = new AffordanceData();
-                    m_AffordanceData[renderer] = affordanceData;
-
-                    // Clones that utilize the standard shader can lose their enabled ZWrite value (1), if it was enabled on the material
-                    foreach (var material in sharedMaterials)
+                    var sharedMaterials = renderer.sharedMaterials;
+                    AffordanceData affordanceData;
+                    if (!m_AffordanceData.TryGetValue(renderer, out affordanceData))
                     {
-                        material.SetFloat(k_ZWritePropertyName, 1);
+                        MaterialUtils.CloneMaterials(renderer); // Clone all materials associated with each renderer once
+                        affordanceData = new AffordanceData();
+                        m_AffordanceData[renderer] = affordanceData;
+
+                        // Clones that utilize the standard shader can lose their enabled ZWrite value (1), if it was enabled on the material
+                        foreach (var material in sharedMaterials)
+                        {
+                            material.SetFloat(k_ZWritePropertyName, 1);
+                        }
                     }
-                }
 
-                var control = affordance.control;
-                var definition = affordanceMapDefinitions.FirstOrDefault(x => x.control == control);
-                if (definition == null)
-                {
-                    definition = new AffordanceDefinition
+                    var control = affordance.control;
+                    var definition = affordanceMapDefinitions.FirstOrDefault(x => x.control == control);
+                    if (definition == null)
                     {
-                        control = control,
-                        visibilityDefinition = defaultAffordanceVisibilityDefinition,
-                        animationDefinition = defaultAffordanceAnimationDefinition
-                    };
-                }
+                        definition = new AffordanceDefinition
+                        {
+                            control = control,
+                            visibilityDefinitions = new[] { defaultAffordanceVisibilityDefinition },
+                            animationDefinitions = new[] { defaultAffordanceAnimationDefinition }
+                        };
+                    }
 
-                affordanceDefinitions[i] = definition;
-                affordanceData.AddAffordance(affordance, definition.visibilityDefinition);
+                    affordanceDefinitions[i] = definition;
+                    affordanceData.AddAffordance(affordance, definition.visibilityDefinitions);
+                }
             }
 
             foreach (var kvp in m_AffordanceData)
@@ -462,17 +472,12 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
             var bodyRenderers = GetComponentsInChildren<Renderer>(true)
                 .Where(x => !m_AffordanceData.ContainsKey(x) && !IsChildOfProxyOrigin(x.transform)).ToList();
 
-            var bodyAffordanceDefinition = new AffordanceDefinition
-            {
-                visibilityDefinition = m_AffordanceMap.bodyVisibilityDefinition
-            };
-
             foreach (var renderer in bodyRenderers)
             {
                 MaterialUtils.CloneMaterials(renderer);
                 var affordanceData = new AffordanceData();
                 m_BodyData.Add(new Tuple<Renderer, AffordanceData>(renderer, affordanceData));
-                affordanceData.AddRenderer(renderer, bodyAffordanceDefinition.visibilityDefinition);
+                affordanceData.AddRenderer(renderer, m_AffordanceMap.bodyVisibilityDefinition);
                 renderer.AddMaterial(m_ProxyBackgroundMaterial);
             }
 
@@ -670,21 +675,24 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
                 if (affordance.control != request.control)
                     continue;
 
-                m_AffordanceData[affordance.renderer].SetVisibility(!request.suppressExisting, request.duration, changedRequest.control);
-
-                this.SetHighlight(affordance.renderer.gameObject, !request.suppressExisting);
-
-                var tooltipText = request.tooltipText;
-                if (!string.IsNullOrEmpty(tooltipText) || request.suppressExisting)
+                foreach (var renderer in affordance.renderers)
                 {
-                    foreach (var tooltip in affordance.tooltips)
+                    m_AffordanceData[renderer].SetVisibility(!request.suppressExisting, request.duration, changedRequest.control);
+
+                    this.SetHighlight(renderer.gameObject, !request.suppressExisting);
+
+                    var tooltipText = request.tooltipText;
+                    if (!string.IsNullOrEmpty(tooltipText) || request.suppressExisting)
                     {
-                        if (tooltip)
+                        foreach (var tooltip in affordance.tooltips)
                         {
-                            data.visibleThisPresentation = false;
-                            tooltip.tooltipText = tooltipText;
-                            this.ShowTooltip(tooltip, true, placement: tooltip.GetPlacement(m_FacingDirection),
-                                becameVisible: data.onBecameVisible);
+                            if (tooltip)
+                            {
+                                data.visibleThisPresentation = false;
+                                tooltip.tooltipText = tooltipText;
+                                this.ShowTooltip(tooltip, true, placement: tooltip.GetPlacement(m_FacingDirection),
+                                    becameVisible: data.onBecameVisible);
+                            }
                         }
                     }
                 }
@@ -706,18 +714,21 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
                 if (affordance.control != request.control)
                     continue;
 
-                m_AffordanceData[affordance.renderer].SetVisibility(false, request.duration, request.control);
-
-                this.SetHighlight(affordance.renderer.gameObject, false);
-
-                if (!string.IsNullOrEmpty(request.tooltipText))
+                foreach (var renderer in affordance.renderers)
                 {
-                    foreach (var tooltip in affordance.tooltips)
+                    m_AffordanceData[renderer].SetVisibility(false, request.duration, request.control);
+
+                    this.SetHighlight(renderer.gameObject, false);
+
+                    if (!string.IsNullOrEmpty(request.tooltipText))
                     {
-                        if (tooltip)
+                        foreach (var tooltip in affordance.tooltips)
                         {
-                            tooltip.tooltipText = string.Empty;
-                            this.HideTooltip(tooltip, true);
+                            if (tooltip)
+                            {
+                                tooltip.tooltipText = string.Empty;
+                                this.HideTooltip(tooltip, true);
+                            }
                         }
                     }
                 }

--- a/Scripts/Proxies/Touch/TouchAffordanceMap.asset
+++ b/Scripts/Proxies/Touch/TouchAffordanceMap.asset
@@ -33,98 +33,98 @@ MonoBehaviour:
     m_HiddenMaterial: {fileID: 0}
   m_AffordanceDefinitions:
   - m_Control: 2
-    m_AnimationDefinition:
-      m_TranslateAxes: 0
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 0
       m_RotateAxes: 1
       m_Min: 20
       m_Max: -25
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 3
-    m_AnimationDefinition:
-      m_TranslateAxes: 1
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 1
       m_RotateAxes: 0
       m_Min: -0.00455765
       m_Max: 0.00455765
       m_ReverseForRightHand: 1
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 17
-    m_AnimationDefinition:
-      m_TranslateAxes: 4
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 4
       m_RotateAxes: 0
       m_Min: 0.001793736
       m_Max: -0.001793736
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 18
-    m_AnimationDefinition:
-      m_TranslateAxes: 4
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 4
       m_RotateAxes: 0
       m_Min: 0.001793736
       m_Max: -0.001793736
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 22
-    m_AnimationDefinition:
-      m_TranslateAxes: 1
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 1
       m_RotateAxes: 0
       m_Min: 0.0002774392
       m_Max: -0.0002774392
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 0
-    m_AnimationDefinition:
-      m_TranslateAxes: 0
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 0
       m_RotateAxes: 2
       m_Min: 15
       m_Max: -15
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 1
-    m_AnimationDefinition:
-      m_TranslateAxes: 0
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 0
       m_RotateAxes: 4
       m_Min: 15
       m_Max: -15
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}

--- a/Scripts/Proxies/Vive/ViveAffordanceMap.asset
+++ b/Scripts/Proxies/Vive/ViveAffordanceMap.asset
@@ -33,126 +33,120 @@ MonoBehaviour:
     m_HiddenMaterial: {fileID: 0}
   m_AffordanceDefinitions:
   - m_Control: 2
-    m_AnimationDefinition:
-      m_TranslateAxes: 0
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 0
       m_RotateAxes: 1
       m_Min: 20
       m_Max: -20
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 3
-    m_AnimationDefinition:
-      m_TranslateAxes: 1
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 1
       m_RotateAxes: 0
       m_Min: 0.0005
       m_Max: -0.0005
       m_ReverseForRightHand: 1
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 18
-    m_AnimationDefinition:
-      m_TranslateAxes: 4
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 4
       m_RotateAxes: 0
       m_Min: 0.0005
       m_Max: -0.0005
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 18
-    m_AnimationDefinition:
-      m_TranslateAxes: 4
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 4
       m_RotateAxes: 0
       m_Min: 0.0005
       m_Max: -0.0005
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 22
-    m_AnimationDefinition:
-      m_TranslateAxes: 2
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 2
       m_RotateAxes: 0
       m_Min: 0.001
       m_Max: -0.001
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
   - m_Control: 0
-    m_AnimationDefinition:
-      m_TranslateAxes: 0
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 0
       m_RotateAxes: 4
       m_Min: -4
       m_Max: 4
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    - m_TranslateAxes: 1
+      m_RotateAxes: 0
+      m_Min: 0.018
+      m_Max: -0.018
+      m_ReverseForRightHand: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
+    - m_VisibilityType: 0
+      m_ColorProperty: _Color
+      m_AlphaProperty: 
+      m_HiddenColor: {r: 1, g: 1, b: 1, a: 0.11764706}
+      m_HiddenAlpha: 0
+      m_HiddenMaterial: {fileID: 0}
   - m_Control: 1
-    m_AnimationDefinition:
-      m_TranslateAxes: 0
+    m_AnimationDefinitions:
+    - m_TranslateAxes: 0
       m_RotateAxes: 1
       m_Min: 4
       m_Max: -4
       m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    - m_TranslateAxes: 4
+      m_RotateAxes: 0
+      m_Min: 0.018
+      m_Max: -0.018
+      m_ReverseForRightHand: 0
+    m_VisibilityDefinitions:
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
       m_HiddenAlpha: 0
       m_HiddenMaterial: {fileID: 0}
-  - m_Control: 0
-    m_AnimationDefinition:
-      m_TranslateAxes: 1
-      m_RotateAxes: 0
-      m_Min: 0.018
-      m_Max: -0.018
-      m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
-      m_ColorProperty: _Color
-      m_AlphaProperty: 
-      m_HiddenColor: {r: 1, g: 1, b: 1, a: 0}
-      m_HiddenAlpha: 0
-      m_HiddenMaterial: {fileID: 0}
-  - m_Control: 1
-    m_AnimationDefinition:
-      m_TranslateAxes: 4
-      m_RotateAxes: 0
-      m_Min: 0.018
-      m_Max: -0.018
-      m_ReverseForRightHand: 0
-    m_VisibilityDefinition:
-      m_VisibilityType: 0
+    - m_VisibilityType: 0
       m_ColorProperty: _Color
       m_AlphaProperty: 
       m_HiddenColor: {r: 1, g: 1, b: 1, a: 0.11764706}

--- a/Scripts/Proxies/Vive/ViveProxy.cs
+++ b/Scripts/Proxies/Vive/ViveProxy.cs
@@ -19,7 +19,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
         [SerializeField]
         GameObject m_RightHandTouchProxyPrefab;
 
-        bool m_IsOculus = false;
+        bool m_IsOculus;
 
         protected override void Awake()
         {
@@ -49,35 +49,42 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
         static void PostAnimate(Affordance[] affordances, AffordanceDefinition[] affordanceDefinitions, Dictionary<Transform, ProxyAnimator.TransformInfo> transformInfos, ActionMapInput input)
         {
             var proxyInput = (ProxyAnimatorInput)input;
-            foreach (var button in affordances)
+            foreach (var affordance in affordances)
             {
-                AffordanceAnimationDefinition affordanceAnimationDefinition = null;
+                AffordanceAnimationDefinition[] definitions = null;
                 foreach (var definition in affordanceDefinitions)
                 {
-                    if (definition.control == button.control)
+                    if (definition.control == affordance.control)
                     {
-                        affordanceAnimationDefinition = definition.animationDefinition;
+                        definitions = definition.animationDefinitions;
                         break;
                     }
                 }
 
-                switch (button.control)
+                if (definitions == null)
+                    continue;
+
+                var transforms = affordance.transforms;
+                for (var i = 0; i < transforms.Length; i++)
                 {
-                    case VRInputDevice.VRControl.LeftStickButton:
-                        if (!proxyInput.stickButton.isHeld)
-                        {
-                            var buttonTransform = button.transform;
-                            var info = transformInfos[buttonTransform];
-                            info.rotationOffset = Vector3.zero;
-                            info.Apply(buttonTransform);
-                        }
-                        break;
-                    case VRInputDevice.VRControl.Analog0:
-                        // TODO: Support multiple transforms per control
-                        // Trackpad touch sphere
-                        //if (affordanceAnimationDefinition.translateAxes != 0)
-                        //    button.renderer.enabled = !Mathf.Approximately(proxyInput.stickX.value, 0) || !Mathf.Approximately(proxyInput.stickY.value, 0);
-                        break;
+                    var transform = transforms[i];
+                    switch (affordance.control)
+                    {
+                        case VRInputDevice.VRControl.LeftStickButton:
+                            if (!proxyInput.stickButton.isHeld)
+                            {
+                                var info = transformInfos[transform];
+                                info.rotationOffset = Vector3.zero;
+                                info.Apply(transform);
+                            }
+
+                            break;
+                        case VRInputDevice.VRControl.Analog0:
+                            // Trackpad touch sphere
+                            if (definitions.Length > i && definitions[i].translateAxes != 0)
+                                affordance.renderers[i].enabled = !Mathf.Approximately(proxyInput.stickX.value, 0) || !Mathf.Approximately(proxyInput.stickY.value, 0);
+                            break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Purpose of this PR**
When we switched to a SerializedObject for ProxyAffordanceMaps, we lost the ability to animate or control visibility on two transforms for a given control ID. The issue is mapping the fields on the prefab to the definitions. The entire map is a single reference, and for the most part things match up 1:1 for each control ID.

The solve is just to use arrays instead of single references for the transforms, renderers, and definitions. We match element 0 to element 0 and so on.  @AndrewTHEManeri and I discussed a future improvement involving custom editors to essentially auto-fill an array index on the elements themselves so that they would stand up to deletions/re-orders, but I'm not sure that is needed at this point.

**Testing status**

Tested on Vive and Rift. Wiggled the buttons and tested the touchpad.

**Technical risk**

Low: Minor code changes and serialized data changes. There are some warnings which we might want to add to help identify bad setup.

**Comments to reviewers**

The highlight will flicker as you cross over the X/Y axis on Vive, which is annoying but I couldn't find the input for "the user is touching the vive." It would require changes to input which are outside the scope of this PR.
  