### PR TITLE
IUpdateInspectors

### DIFF
--- a/Scripts/Core/InterfaceConnectors/WorkspaceModuleConnector.cs
+++ b/Scripts/Core/InterfaceConnectors/WorkspaceModuleConnector.cs
@@ -1,5 +1,6 @@
 ﻿#if UNITY_EDITOR && UNITY_2017_2_OR_NEWER
 using UnityEditor.Experimental.EditorVR.Modules;
+using UnityEditor.Experimental.EditorVR.Workspaces;
 
 namespace UnityEditor.Experimental.EditorVR.Core
 {
@@ -11,6 +12,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             {
                 ICreateWorkspaceMethods.createWorkspace = provider.CreateWorkspace;
                 IResetWorkspacesMethods.resetWorkspaceRotations = provider.ResetWorkspaceRotations;
+                IUpdateInspectorsMethods.updateInspectors = provider.UpdateInspectors;
             }
 
             public void ConnectInterface(object target, object userData = null)
@@ -20,9 +22,20 @@ namespace UnityEditor.Experimental.EditorVR.Core
                 var allWorkspaces = target as IAllWorkspaces;
                 if (allWorkspaces != null)
                     allWorkspaces.allWorkspaces = workspaceModule.workspaces;
+
+                var inspectorWorkspace = target as IInspectorWorkspace;
+                if (inspectorWorkspace != null)
+                    workspaceModule.AddInspector(inspectorWorkspace);
             }
 
-            public void DisconnectInterface(object target, object userData = null) { }
+            public void DisconnectInterface(object target, object userData = null)
+            {
+                var workspaceModule = evr.GetModule<WorkspaceModule>();
+
+                var inspectorWorkspace = target as IInspectorWorkspace;
+                if (inspectorWorkspace != null)
+                    workspaceModule.RemoveInspector(inspectorWorkspace);
+            }
         }
     }
 }

--- a/Scripts/Interfaces/Capability/IUpdateInspectors.cs
+++ b/Scripts/Interfaces/Capability/IUpdateInspectors.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using UnityEngine;
+
+namespace UnityEditor.Experimental.EditorVR.Workspaces
+{
+    /// <summary>
+    /// Provides UpdateInspectors method used to update inspectors when their content has changed
+    /// </summary>
+    public interface IUpdateInspectors
+    {
+    }
+
+    public static class IUpdateInspectorsMethods
+    {
+        internal static Action<GameObject, bool> updateInspectors;
+
+        /// <summary>
+        /// Update all inspectors or inspectors of the specified object
+        /// </summary>
+        /// <param name="go">(Optional) Only update inspectors on this object. If null, update all inspectors</param>
+        /// <param name="fullRebuild">(Optional) Whether to rebuild the whole inspector (for added/removed components)</param>
+        public static void UpdateInspectors(this IUpdateInspectors obj, GameObject go = null, bool fullRebuild = false)
+        {
+            updateInspectors(go, fullRebuild);
+        }
+    }
+}

--- a/Scripts/Interfaces/Capability/IUpdateInspectors.cs.meta
+++ b/Scripts/Interfaces/Capability/IUpdateInspectors.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: d68d29a61040f294684d4755f6916123
+timeCreated: 1515180714
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/ListView/ListViewControllerBase.cs
+++ b/Scripts/ListView/ListViewControllerBase.cs
@@ -201,7 +201,8 @@ namespace ListView
                 t.localRotation = targetRotation;
             }
 
-            t.SetSiblingIndex(order);
+            if (t.GetSiblingIndex() != order)
+                t.SetSiblingIndex(order);
         }
 
         protected virtual Vector3 GetObjectSize(GameObject g)

--- a/Scripts/Modules/WorkspaceModule.cs
+++ b/Scripts/Modules/WorkspaceModule.cs
@@ -79,6 +79,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         internal List<IWorkspace> workspaces { get { return m_Workspaces; } }
 
         readonly List<IWorkspace> m_Workspaces = new List<IWorkspace>();
+        readonly List<IInspectorWorkspace> m_Inspectors = new List<IInspectorWorkspace>();
 
         internal event Action<IWorkspace> workspaceCreated;
         internal event Action<IWorkspace> workspaceDestroyed;
@@ -231,6 +232,24 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         static void ResetRotation(IWorkspace workspace, Vector3 forward)
         {
             workspace.transform.rotation = Quaternion.LookRotation(forward) * DefaultWorkspaceTilt;
+        }
+
+        internal void UpdateInspectors(GameObject obj = null, bool fullRebuild = false)
+        {
+            foreach (var inspector in m_Inspectors)
+            {
+                inspector.UpdateInspector(obj, fullRebuild);
+            }
+        }
+
+        public void AddInspector(IInspectorWorkspace inspectorWorkspace)
+        {
+            m_Inspectors.Add(inspectorWorkspace);
+        }
+
+        public void RemoveInspector(IInspectorWorkspace inspectorWorkspace)
+        {
+            m_Inspectors.Remove(inspectorWorkspace);
         }
     }
 }

--- a/Workspaces/InspectorWorkspace/InspectorWorkspace.cs
+++ b/Workspaces/InspectorWorkspace/InspectorWorkspace.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     [MainMenuItem("Inspector", "Workspaces", "View and edit GameObject properties")]
-    sealed class InspectorWorkspace : Workspace, ISelectionChanged
+    sealed class InspectorWorkspace : Workspace, ISelectionChanged, IInspectorWorkspace
     {
         public new static readonly Vector3 DefaultBounds = new Vector3(0.3f, 0.1f, 0.5f);
 
@@ -365,6 +365,12 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         {
             SetIsLocked();
             OnButtonClicked(rayOrigin);
+        }
+
+        public void UpdateInspector(GameObject obj, bool fullRebuild = false)
+        {
+            if (obj == null || obj == m_SelectedObject)
+                UpdateCurrentObject(fullRebuild);
         }
     }
 }

--- a/Workspaces/InspectorWorkspace/Scripts/IInspectorWorkspace.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/IInspectorWorkspace.cs
@@ -1,0 +1,6 @@
+﻿using UnityEngine;
+
+interface IInspectorWorkspace
+{
+    void UpdateInspector(GameObject obj, bool fullRebuild = false);
+}

--- a/Workspaces/InspectorWorkspace/Scripts/IInspectorWorkspace.cs.meta
+++ b/Workspaces/InspectorWorkspace/Scripts/IInspectorWorkspace.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 60d487597c5f0ef4b9f3f0f7bc37ca55
+timeCreated: 1515180962
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workspaces/InspectorWorkspace/Scripts/InspectorListViewController.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/InspectorListViewController.cs
@@ -124,6 +124,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                 depth = depth
             });
 
+            order = m_ListItems.Count - 1;
             while (m_UpdateStack.Count > 0)
             {
                 var stackData = m_UpdateStack.Pop();
@@ -153,7 +154,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                     if (offset + scrollOffset + itemSize.z < 0 || offset + scrollOffset > m_Size.z)
                         Recycle(index);
                     else
-                        UpdateInspectorItem(datum, order++, offset, depth, expanded, ref doneSettling);
+                        UpdateInspectorItem(datum, order--, offset, depth, expanded, ref doneSettling);
 
                     offset += itemSize.z;
 
@@ -203,8 +204,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             var targetPosition = m_StartPosition + (offset + m_ScrollOffset) * Vector3.forward;
             var targetRotation = Quaternion.identity;
 
-            // order is reversed because Inspector draws bottom-to-top, hence the "0" below
-            UpdateItemTransform(t, 0, targetPosition, targetRotation, dontSettle, ref doneSettling);
+            UpdateItemTransform(t, order, targetPosition, targetRotation, dontSettle, ref doneSettling);
         }
 
         protected override InspectorListItem GetItem(InspectorData listData)

--- a/Workspaces/PolyWorkspace/Scripts/PolyGridViewController.cs
+++ b/Workspaces/PolyWorkspace/Scripts/PolyGridViewController.cs
@@ -251,7 +251,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             t.localPosition = Vector3.Lerp(t.localPosition, m_StartPosition + zOffset * Vector3.back + xOffset * Vector3.right, k_PositionFollow);
             t.localRotation = Quaternion.identity;
 
-            t.SetSiblingIndex(order);
+            if (t.GetSiblingIndex() != order)
+                t.SetSiblingIndex(order);
         }
 
         protected override PolyGridItem GetItem(PolyGridAsset data)

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
@@ -213,7 +213,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             t.localPosition = Vector3.Lerp(t.localPosition, m_StartPosition + zOffset * Vector3.back + xOffset * Vector3.right, k_PositionFollow);
             t.localRotation = Quaternion.identity;
 
-            t.SetSiblingIndex(order);
+            if (t.GetSiblingIndex() != order)
+                t.SetSiblingIndex(order);
         }
 
         protected override AssetGridItem GetItem(AssetData data)


### PR DESCRIPTION
### Purpose of this PR
Add an interface for manually updating inspectors, i.e. when adding components (see #456)

### Testing status
Tested by adding code in Selection tool to call UpdateInspectors on trigger press. Update is called successfully.

### Technical risk
Low: Does not affect existing functionality

### Comments to reviewers
We should look to use internal callbacks wherever possible, but I didn't find one that updates just when the inspector updates (without relying on an actual Inspector window). This will have to do, for now.